### PR TITLE
Fix index.html issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
                         <div class="separator w10"></div>
                         <h1 class="xbiggest flex-item-center txtcenter mtxl">About AndrOBD</h1>
                         
-                        <p class="flex-item-center h3-like txtcenter mts">AndrOBD allows you to use your phone/tablet to connect to your car's on-board diagnostics system via any ELM327 bluetooth adapter. Plus it's <strong>open source</strong>, as well as being <strong>completely free</strong>. It was originally started <strong>fr3ts0n</strong>.</p>
+                        <p class="flex-item-center h3-like txtcenter mts">AndrOBD allows you to use your phone/tablet to connect to your car's on-board diagnostics system via any ELM327 bluetooth adapter. Plus it's <strong>open source</strong>, as well as being <strong>completely free</strong>. It was originally started by <strong>fr3ts0n</strong>.</p>
                         <div class="flex-item-center"><a class="button flex-item-center mtxl" href="https://github.com/fr3ts0n/AndrOBD">View it on GitHub</a></div>
                     </div>
                 </section>
@@ -99,20 +99,20 @@
                         <div class="features-container mtxl">
                             <div class="grid-2 has-gutter">
                                 <div class="Media mbl">
-                                    <div class="Media-body big prm"><strong>Do you have a chat I can join? </strong>Yes, we do. For general discussions, please join this <a href ="https://t.me/joinchat/G60ltQv5CCEQ94BZ5yWQbg">Telegram chat.</a> For updates on test releases, please join this <a href ="https://t.me/AndrOBD_dev">Telegram chat.</a></div>
+                                    <div class="Media-body big prm"><strong>Do you have a chat I can join? </strong><br>Yes, we do. For general discussions, please join this <a href ="https://t.me/joinchat/G60ltQv5CCEQ94BZ5yWQbg">Telegram chat.</a> For updates on test releases, please join this <a href ="https://t.me/AndrOBD_dev">Telegram chat.</a></div>
                                 </div>
                                 <div class="Media mbl">
-                                    <div class="Media-body big prm"><strong>How can I report a bug?</strong> You can use <a href="https://github.com/fr3ts0n/AndrOBD/issues">GitHub issues</a>. to report any issues.</div>
+                                    <div class="Media-body big prm"><strong>How can I report a bug?</strong><br>You can use <a href="https://github.com/fr3ts0n/AndrOBD/issues">GitHub issues</a>. to report any issues.</div>
                                 </div>
                             </div>
                             
                             <div class="grid-2 has-gutter">
                                 <div class="Media mbl">
-                                    <div class="Media-body big prm"><strong>How can I support the project?</strong> One area you can help with is maintaining the project on <a href ="https://github.com/fr3ts0n/AndrOBD">GitHub.</a> If that's not your type of thing, you can fincailly support the project by donating on <a href ="https://www.paypal.me/fr3ts0n">Paypal</a> or Bitcoin (19UApzsc5eDJ5VNDNYCA1bpszPnkcpWeFP). Thanks to John Zimmerer, Martin Bourdoiseau, Jeffrey O'Connell & Christoph Schmid for their support.</div>
+                                    <div class="Media-body big prm"><strong>How can I support the project?</strong><br>One area you can help with is maintaining the project on <a href ="https://github.com/fr3ts0n/AndrOBD">GitHub.</a> If that's not your type of thing, you can financially support the project by donating on <a href ="https://www.paypal.me/fr3ts0n">Paypal</a> or Bitcoin (19UApzsc5eDJ5VNDNYCA1bpszPnkcpWeFP). Thanks to John Zimmerer, Martin Bourdoiseau, Jeffrey O'Connell & Christoph Schmid for their support.</div>
                                 </div>
                                 <div class="Media mbl">
                                     
-                                    <div class="Media-body big prm"><strong>What plugins are available?</strong> You can learn more about plugins <a href="https://github.com/fr3ts0n/AndrOBD-Plugin">here</a></div>
+                                    <div class="Media-body big prm"><strong>What plugins are available?</strong><br>You can learn more about plugins <a href="https://github.com/fr3ts0n/AndrOBD-Plugin">here</a></div>
                                 </div>
                             </div>
                             

--- a/index.html
+++ b/index.html
@@ -42,6 +42,8 @@
                             <div class="mtxl w150p" style = "margin-top: 5rem;"></div>
                             <button class="button-primary txtcenter main-cta" onclick="location.href='https://f-droid.org/packages/com.fr3ts0n.ecu.gui.androbd/';">Download on F-Droid</button>
                             <div class="txtcenter mtm cpointer secondary-cta"><a class="h4-like" href="https://github.com/fr3ts0n/AndrOBD">View source on GitHub</a></div>
+                            <div class="txtcenter mtm cpointer secondary-cta"><a class="h4-like" href="https://github.com/fr3ts0n/AndrOBD/wiki">View documentation on the Wiki</a></div>
+                            
                         </div>
                     </div>
                 </section>


### PR DESCRIPTION
Fixed a few issues addressed by @aha999 in #103. This will fix:

typo on the landing page: "fincailly" instead of financially.
typo: "started fr3ts0n" instead of "started by fr3ts0n"
i think that FAQ questions could be one line above their answers... Like: