### PR TITLE
fix: Use FileProvider

### DIFF
--- a/androbd/build.gradle
+++ b/androbd/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 34
     defaultConfig {
         applicationId 'com.fr3ts0n.ecu.gui.androbd'
         minSdkVersion 17
@@ -44,4 +44,5 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.github.mik3y:usb-serial-for-android:3.3.0'
     implementation 'com.github.anastr:speedviewlib:1.6.1'
+    implementation 'androidx.core:core:1.12.0'
 }

--- a/androbd/src/main/AndroidManifest.xml
+++ b/androbd/src/main/AndroidManifest.xml
@@ -61,6 +61,15 @@
             android:name=".PidCustomization"
             android:label="@string/customize_display"
             android:configChanges="touchscreen|orientation|screenSize" />
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/MainActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/MainActivity.java
@@ -54,6 +54,8 @@ import android.widget.ListView;
 import android.widget.Spinner;
 import android.widget.Toast;
 
+import androidx.core.content.FileProvider;
+
 import com.fr3ts0n.androbd.plugin.Plugin;
 import com.fr3ts0n.androbd.plugin.mgr.PluginManager;
 import com.fr3ts0n.ecu.EcuCodeItem;
@@ -1902,7 +1904,7 @@ public class MainActivity extends PluginManager
         File file = new File(FileHelper.getPath(this));
         Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
-        Uri data = Uri.fromFile(file);
+        Uri data = FileProvider.getUriForFile(getApplicationContext(), getApplicationContext().getPackageName() + ".provider", file);
         String type = "*/*";
         intent.setDataAndType(data, type);
         startActivityForResult(intent, REQUEST_SELECT_FILE);

--- a/androbd/src/main/res/xml/provider_paths.xml
+++ b/androbd/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path name="external_files" path="."/>
+</paths>

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20"
+        classpath 'com.android.tools.build:gradle:8.1.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0"
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false
 android.nonTransitiveRClass=true
+android.useAndroidX=true
 org.gradle.unsafe.configuration-cache=true


### PR DESCRIPTION
Fixes #243

Followed the steps from Stack Overflow (to use FileProvider): https://stackoverflow.com/a/38858040
(The comment "I just needed to add intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)" didn't apply here, I tried.)

Upgraded some dependencies along the way when necessary, as little as possible.

Removed `android.enableJetifier=true` from `gradle.properties` again (was automatically added as part of migration to Android X) since "

> If your project already has the enableJetifier flag and it's turned on, you can run Build Analyzer’s Jetifier check to confirm if it’s actually needed.

https://developer.android.com/jetpack/androidx/migrate
and the analyzer said it's not needed.