### PR TITLE
chore: update deprecated CI actions and CI badge URL

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,12 +8,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: set up JDK 17
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
-        java-version: 17
+        java-version: '17'
+        distribution: 'temurin'
     - name: Build with Gradle
       run: ./gradlew build

--- a/.github/workflows/android_beta_apk.yml
+++ b/.github/workflows/android_beta_apk.yml
@@ -7,14 +7,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
       - name: set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: '17'
+          distribution: 'temurin'
 
       - name: Build with Gradle
         run: ./gradlew assembleDebug --stacktrace
@@ -22,5 +23,5 @@ jobs:
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
-          name: androbd-beta 
+          name: androbd-beta
           path: ./**/*.apk

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 AndrOBD allows your Android device to connect to your car's on-board diagnostics system via any ELM327 compatible OBD adapter, display various information & perform operations.
 It is open source and completely free. The application also has a built in Demo mode that simulates live data, so you don't require an adapter to test it.
 
-![Android CI](https://github.com/fr3ts0n/AndrOBD/workflows/Android%20CI/badge.svg)
+![Android CI](https://github.com/fr3ts0n/AndrOBD/actions/workflows/android.yml/badge.svg)
 [![GitHub issues](https://img.shields.io/github/issues/fr3ts0n/AndrOBD?color=red)](https://github.com/fr3ts0n/AndrOBD/issues)
 [![Liberapay receiving](https://img.shields.io/liberapay/receives/AndrOBD?label=Liberapay)](https://liberapay.com/AndrOBD/donate/)
 [![Subreddit subscribers](https://img.shields.io/reddit/subreddit-subscribers/AndrOBD?color=orange)](https://www.reddit.com/r/AndrOBD/)


### PR DESCRIPTION
Both CI workflows (`android.yml` and `android_beta_apk.yml`) were using `actions/checkout@v1` and `actions/setup-java@v1`, which are deprecated and run on Node.js 12 (end-of-life). This updates them to the current stable versions.

**Changes:**
- `actions/checkout@v1` → `@v4` in both workflows
- `actions/setup-java@v1` → `@v4` in both workflows; adds the now-required `distribution: temurin` parameter (Eclipse Temurin, the GitHub-recommended OpenJDK distribution)
- Updates the README CI badge URL from the deprecated `/workflows/` path to the current `/actions/workflows/` path

No build logic is changed.