### PR TITLE
fix: guard mBtWorkerThread null in BtCommService.write()

### DIFF
--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/BtCommService.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/BtCommService.java
@@ -208,8 +208,8 @@ public class BtCommService extends CommService
 	@Override
 	public synchronized void write(byte[] out)
 	{
-		// Perform the write un-synchronized
-		mBtWorkerThread.write(out);
+		if (mBtWorkerThread != null)
+			mBtWorkerThread.write(out);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #322.

`write()` was the only synchronized method in `BtCommService` that did not check `mBtWorkerThread` before use. Calling `write()` while in LISTEN (before any connection), OFFLINE (after `stop()`), or CONNECTING (while the connect thread is running) threw a `NullPointerException`.

One-line fix as discussed in the issue:

```java
public synchronized void write(byte[] out)
{
    if (mBtWorkerThread != null)
        mBtWorkerThread.write(out);
}
```