### PR TITLE
fix: remove static from WakeLock fields in ChartActivity and DashBoardActivity

### DIFF
--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/ChartActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/ChartActivity.java
@@ -112,7 +112,7 @@ public class ChartActivity extends Activity
 	/**
 	 * the wake lock to keep app communication alive
 	 */
-	private static WakeLock wakeLock;
+	private WakeLock wakeLock;
 
 	private static ListAdapter mAdapter = null;
 

--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/DashBoardActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/DashBoardActivity.java
@@ -69,7 +69,7 @@ public class DashBoardActivity extends Activity
 	/**
 	 * the wake lock to keep app communication alive
 	 */
-	private static PowerManager.WakeLock wakeLock;
+	private PowerManager.WakeLock wakeLock;
 	private transient ObdGaugeAdapter adapter;
 	private transient GridView grid;
 


### PR DESCRIPTION
Fixes #323.

Both `ChartActivity` and `DashBoardActivity` declared their `WakeLock` as `private static`. On a configuration change (e.g. screen rotation), Android destroys and recreates the Activity; `onCreate()` assigns a fresh `WakeLock` to the static field, silently orphaning the previous instance. The orphaned lock is never released, so the CPU stays locked awake until the process is killed — even after the user leaves the chart or dashboard screen.

Fix removes `static` from both fields so each Activity instance owns its own lock, and the existing `onDestroy()` release always targets the correct object.