### PR TITLE
fix: extend chart flat line for static sensor values

### DIFF
--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/ChartActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/ChartActivity.java
@@ -227,6 +227,18 @@ public class ChartActivity extends Activity
 		{
 
 			if (msg.what == MainActivity.MESSAGE_UPDATE_VIEW) {
+				// Carry-forward: if a series hasn't received a new value for more than
+				// 1.5 s, add a duplicate point at the current time so the flat line
+				// extends to the right rather than being absent (issue #180).
+				long now = System.currentTimeMillis();
+				for (org.achartengine.model.XYSeries series : sensorData.getSeries())
+				{
+					int count = series.getItemCount();
+					if (count > 0 && now - (long) series.getX(count - 1) > 1500)
+					{
+						series.add(now, series.getY(count - 1));
+					}
+				}
 				/* update chart */
 				chartView.invalidate();
 			} else if (msg.what == MainActivity.MESSAGE_TOOLBAR_VISIBLE) {


### PR DESCRIPTION
Fixes #180.

When a sensor value doesn't change, no new data points are added to the `XYSeries`, so the chart renderer draws nothing (or just a dot) for that period — e.g. a warm-up lambda value that stays at 1.0 disappears instead of showing as a flat line, even though the underlying .csv data is correct.

Implements the carry-forward workaround described in the issue: in the existing 1-second chart refresh handler, each series is checked — if its most recent data point is older than 1.5s, a duplicate point is appended at the current time with the same Y value. This extends the flat line continuously to the right. Runs on the main thread inside the existing `Handler`, so no additional synchronisation is needed.