### PR TITLE
fix: null-guard BluetoothAdapter and socket in BtCommService

### DIFF
--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/BtCommService.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/BtCommService.java
@@ -64,7 +64,8 @@ public class BtCommService extends CommService
 		// Always cancel discovery because it will slow down a connection
 		// Member fields
 		BluetoothAdapter mAdapter = BluetoothAdapter.getDefaultAdapter();
-		mAdapter.cancelDiscovery();
+		if (mAdapter != null)
+			mAdapter.cancelDiscovery();
 		
 		// set up protocol handlers
 		elm.addTelegramWriter(ser);
@@ -264,17 +265,24 @@ public class BtCommService extends CommService
 				StringBuilder message = new StringBuilder(msg);
 				// dump supported UUID's
 				message.append(" - UUIDs:");
-				ParcelUuid[] uuids = socket.getRemoteDevice().getUuids();
-				if(uuids != null)
+				if (socket != null)
 				{
-					for (ParcelUuid uuid: uuids)
+					ParcelUuid[] uuids = socket.getRemoteDevice().getUuids();
+					if(uuids != null)
 					{
-						message.append(uuid.getUuid().toString()).append(",");
+						for (ParcelUuid uuid: uuids)
+						{
+							message.append(uuid.getUuid().toString()).append(",");
+						}
+					}
+					else
+					{
+						message.append("NONE (Invalid BT implementation)");
 					}
 				}
 				else
 				{
-					message.append("NONE (Invalid BT implementation)");
+					message.append("NONE (null socket)");
 				}
 				log.log(Level.INFO, message.toString());
 			}


### PR DESCRIPTION
Addresses #299 — two null-guard issues spotted while investigating that report.

**1. Constructor: no null guard on `getDefaultAdapter()`**

`BluetoothAdapter.getDefaultAdapter()` is deprecated since API 31 and can return `null` on devices without Bluetooth hardware, or if the OS revokes the adapter reference mid-flow (permission revocation appears more aggressive on Android 16). If `mAdapter` is null, the constructor crashed with an NPE before any Demo-mode fallback could be reached. Now guarded before calling `cancelDiscovery()`.

**2. `logSocketUuids()`: null socket dereference**

`socket` can be null if `createRfcommSocketToServiceRecord()` threw before `mmSocket` was assigned. Guarded before calling `getRemoteDevice()`.

**Note:** not build-verified locally — no Android SDK configured in this environment. Both changes are one-line null guards following the existing pattern already used elsewhere in this file (`mBtWorkerThread` checks in #324).