### PR TITLE
fix: move lint config to correct android{} scope

### DIFF
--- a/androbd/build.gradle
+++ b/androbd/build.gradle
@@ -23,11 +23,14 @@ android {
             sourceCompatibility JavaVersion.VERSION_17
             targetCompatibility JavaVersion.VERSION_17
         }
+    }
 
-        lintOptions {
-            // Override lint error on targetSdkVersion
-            abortOnError = false
-        }
+    lint {
+        // abortOnError was previously inside defaultConfig{} where AGP ignores it.
+        // Moved here (android{} level) so it takes effect. To enforce lint on new
+        // code, run ./gradlew lint, commit the generated lint-baseline.xml, and
+        // remove this line.
+        abortOnError false
     }
 }
 


### PR DESCRIPTION
`lintOptions { abortOnError = false }` was nested inside `defaultConfig{}`, where the Android Gradle Plugin doesn't recognise it — the block was being silently ignored, so lint failures weren't actually being suppressed, they just weren't being caught in the first place.

Moved to a `lint{}` block at the `android{}` level (the correct DSL location since AGP 7.0) so the setting actually takes effect. Kept `abortOnError = false` for now to avoid breaking the build on any existing lint issues.

Natural next step once this lands: run `./gradlew lint`, commit the generated baseline, then remove `abortOnError = false` so new issues actually fail the build — happy to follow up with that if useful.