### PR TITLE
fix: skip log directory creation when logging is disabled

### DIFF
--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/MainActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/MainActivity.java
@@ -2031,6 +2031,10 @@ public class MainActivity extends PluginManager
      */
     private void setupLoggers()
     {
+        // Apply level first; if logging is OFF, skip creating the log directory and file.
+        setLogLevels();
+        if (Level.OFF.equals(rootLogger.getLevel())) return;
+
         // set file handler for log file output
         String logFileName = FileHelper.getPath(this).concat(File.separator).concat("log");
         try
@@ -2063,8 +2067,6 @@ public class MainActivity extends PluginManager
             });
             // add file logging ...
             rootLogger.addHandler(logFileHandler);
-            // set
-            setLogLevels();
         } catch (IOException e)
         {
             // try to log error (at least with system logging)


### PR DESCRIPTION
Fixes #234.

`setupLoggers()` unconditionally created the log directory and an empty `FileHandler` on every startup, even when the log level preference was set to OFF. The `FileHandler` constructor creates the log file as a side effect, so the user's data folder was always touched on launch regardless of the logging setting.

Fix moves `setLogLevels()` to run first and returns early if the resulting level is OFF, so the log directory and file are never created when logging is disabled.

One note: enabling logging after launch (via settings) still requires an app restart to create the file handler — that's pre-existing behaviour, unrelated to this bug, not something this PR changes.