### PR TITLE
fix: add descriptions to logging level options in settings

### DIFF
--- a/androbd/src/main/res/values/strings.xml
+++ b/androbd/src/main/res/values/strings.xml
@@ -110,6 +110,17 @@ period of time while the ECU recalibrates itself.
         <item>FINEST</item>
         <item>ALL</item>
     </string-array>
+    <string-array name="logging_options_display">
+        <item>OFF — no logging</item>
+        <item>SEVERE — errors only</item>
+        <item>WARNING — errors and warnings</item>
+        <item>INFO — standard diagnostic information</item>
+        <item>CONFIG — configuration messages</item>
+        <item>FINE — detailed debug (may affect performance)</item>
+        <item>FINER — more detailed debug</item>
+        <item>FINEST — maximum detail (may affect performance)</item>
+        <item>ALL — all messages</item>
+    </string-array>
     <!--
     * key values for restore options
     * - must align with enum MainActivity.PRESELECT

--- a/androbd/src/main/res/xml/settings.xml
+++ b/androbd/src/main/res/xml/settings.xml
@@ -264,7 +264,7 @@
             <ListPreference
                 android:defaultValue="INFO"
                 android:dialogTitle="@string/logging_level"
-                android:entries="@array/logging_options"
+                android:entries="@array/logging_options_display"
                 android:entryValues="@array/logging_options"
                 android:key="log_master"
                 android:summary="@string/logging_level_description"


### PR DESCRIPTION
Fixes #198.

The logging level selector showed bare Java `Level` names (OFF, SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST, ALL) with no indication of what each level actually captures. Users had no way to choose an appropriate level without prior knowledge of Java's logging levels.

Adds a new `logging_options_display` array with a short description alongside each level name (e.g. "FINE — detailed debug (may affect performance)"). The `entryValues` are unchanged — the bare level names still get parsed by `Level.parse()` — only the displayed labels are updated.