### PR TITLE
ci: upload debug APK to GitHub release on V* tags

### DIFF
--- a/.github/workflows/release_apk.yml
+++ b/.github/workflows/release_apk.yml
@@ -15,7 +15,7 @@ jobs:
           submodules: true
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/release_apk.yml
+++ b/.github/workflows/release_apk.yml
@@ -1,0 +1,29 @@
+name: Release APK
+
+on:
+  push:
+    tags:
+      - 'V*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Upload APK to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./**/*.apk


### PR DESCRIPTION
`android.yml` runs `./gradlew build` but attaches nothing to releases — V2.7.9, V2.7.7, and V2.7.6 all have empty release assets, so there's no APK for users to sideload without building from source themselves.

Adds `release_apk.yml`: triggers on tags matching `V*`, builds a debug APK (no release signing config exists in this repo yet, so debug is the only build that succeeds unattended), and attaches it to the GitHub release via `softprops/action-gh-release`. Uses `checkout@v4` and `setup-java@v4`, matching `android.yml` and `android_beta_apk.yml`.

This is a different mechanism from the existing `android_beta_apk.yml` — that one is manual-trigger only and uploads to Actions artifacts (needs a GitHub login + the Actions tab to find), not a public release asset on the Releases page.

Posting this now given #331 — happy to adjust if you'd rather this wait, or if a release-signed build is preferred once signing is set up.