### PR TITLE
feat: Phase 1 Material theme migration (minSdk 17->23)

### DIFF
--- a/androbd/build.gradle
+++ b/androbd/build.gradle
@@ -10,7 +10,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 17
+        minSdkVersion 23
         targetSdkVersion 36
         versionCode 20710
         versionName 'V2.7.10'
@@ -43,6 +43,8 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.10.0'
     // core:1.12.0 to keep supporting minSdk 17
     implementation 'androidx.core:core:1.12.0'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'com.google.android.material:material:1.12.0'
 
     // Local (JVM) unit tests
     testImplementation 'junit:junit:4.13.2'

--- a/androbd/src/main/res/values/styles.xml
+++ b/androbd/src/main/res/values/styles.xml
@@ -1,10 +1,10 @@
 <resources>
     <!-- Application theme. -->
-    <style name="AppTheme" parent="@android:style/Theme.DeviceDefault.Light.DarkActionBar" >
+    <style name="AppTheme" parent="Theme.Material3.Light" >
         <item name="android:activatedBackgroundIndicator">@drawable/activated_background</item>
         <item name="android:fitsSystemWindows">true</item>
     </style>
-    <style name="AppTheme.Dark" parent="@android:style/Theme.DeviceDefault" >
+    <style name="AppTheme.Dark" parent="Theme.Material3.Dark" >
         <item name="android:activatedBackgroundIndicator">@drawable/activated_background</item>
         <item name="android:fitsSystemWindows">true</item>
     </style>


### PR DESCRIPTION
Phase 1 of the staged GUI redesign discussed on #104 — theme baseline only, no layout changes.

## What this does
- Bumps minSdk 17 → 23 (drops Android 4.2–5.1, per the discussion on #104)
- Adds `androidx.appcompat:appcompat:1.7.0` and `com.google.android.material:material:1.12.0`
- Swaps `styles.xml` parents from `Theme.DeviceDefault*` to `Theme.Material3.Light`/`Theme.Material3.Dark`
  - Kept the existing manual `setTheme()`-based day/night switching intact (driven by a `nightMode` preference checked in 6 activities, not resource-qualifier DayNight) — used explicit Light/Dark parents rather than `.DayNight`
  - Used non-`.NoActionBar` variants to avoid requiring a `Toolbar` in every layout

Builds clean (`assembleDebug`/`assembleRelease`) with no other changes.

## Still open: APK size
As flagged on #104, this isn't the ~200-300KB I originally estimated — measured impact is real:

| | master | this branch |
|---|---|---|
| debug | 2.8 MB | 6.8 MB |
| release (unsigned) | 2.3 MB | 5.6 MB |

~3.3 MB even in the release build, because the project has no `minifyEnabled`/R8 shrinking configured anywhere yet. Posting this PR now since your release (V2.7.10) has shipped per your sequencing, but happy to hold merge until we've settled whether to accept this size or do R8 shrinking as a prerequisite first — your call, discussed on #104.

Closes nothing yet — first of the staged phases from #104.