### PR TITLE
feat: add F-Droid changelog metadata for V2.6.15 – V2.7.10

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/20615.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20615.txt
@@ -1,0 +1,5 @@
+V2.6.15 - Library Updates and Bug Fixes
+
+* Updated USB serial communication library to v3.9.0
+* Fixed build configuration issue (#281)
+* Translation updates: Spanish, Turkish, Portuguese, Czech, Dutch, Amharic, Italian, Swedish, Catalan, Russian

--- a/fastlane/metadata/android/en-US/changelogs/20704.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20704.txt
@@ -1,0 +1,8 @@
+V2.7.4 - BLE Device Support
+
+* Added Bluetooth Low Energy (BLE) OBD adapter support
+* Added themed and monochrome launcher icon (Android 13+)
+* Added searchable multi-select list in settings
+* Improved menu structure and organisation
+* Background service and resource optimisation
+* Restored previously missing menu items

--- a/fastlane/metadata/android/en-US/changelogs/20706.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20706.txt
@@ -1,0 +1,4 @@
+V2.7.6 - SDK36 Support
+
+* Updated target SDK to Android 16 (API level 36)
+* Added in-app language selection

--- a/fastlane/metadata/android/en-US/changelogs/20707.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20707.txt
@@ -1,0 +1,4 @@
+V2.7.7 - SDK36 Consistency Fixes
+
+* Fixed UI theme consistency issues
+* Fixed Bluetooth and BLE permission handling across Android versions

--- a/fastlane/metadata/android/en-US/changelogs/20709.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20709.txt
@@ -1,0 +1,6 @@
+V2.7.9 - Fixes / Updates
+
+* Fixed Bluetooth permission declarations to cover the full Android version range (4.2–16 / API 17–36)
+* Fixed file picker not showing external storage when loading .obd recording files
+* Fixed app freeze (ANR) when loading external PID or conversion files on startup
+* Improved test coverage across library, app, and plugin framework

--- a/fastlane/metadata/android/en-US/changelogs/20710.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20710.txt
@@ -1,0 +1,10 @@
+V2.7.10 - Fixes / Updates
+
+* Fixed Bluetooth communication crash on some devices (null-guard for missing/revoked Bluetooth adapter)
+* Fixed WakeLock leak on screen rotation in Chart and Dashboard views
+* Fixed chart display for sensors that stop changing (now shows a flat line instead of a gap)
+* Fixed log directory being recreated even when logging is disabled
+* Added descriptions to logging level and ECU selector options in Settings
+* Added CONTRIBUTING.md for new contributors
+* Updated CI configuration
+* Translation updates: Chinese (Simplified), Finnish, German


### PR DESCRIPTION
Closes #169.

## What this does
`fastlane/metadata/android/en-US/changelogs/` only contained an entry for V2.0.0 (code 20000). F-Droid reads these files to show "What's new" text in the app listing. Adds changelog files for V2.6.15 through V2.7.10 (the six most recent releases), so F-Droid users can see what changed before updating.

The V2.7.10 entry was added after today's release shipped, so the branch is current as of this release rather than stopping at V2.7.9.

Metadata only, no code changes.