### PR TITLE
fix: show user-assigned Bluetooth alias in device list

### DIFF
--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/BtDeviceListActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/BtDeviceListActivity.java
@@ -110,7 +110,14 @@ public class BtDeviceListActivity extends Activity
 														 parent,
 											 false);
 					}
-					tv.setText(String.format("%s\n%s", dev.getName(), dev.getAddress()));
+					String displayName;
+					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+						String alias = dev.getAlias();
+						displayName = (alias != null && !alias.isEmpty()) ? alias : dev.getName();
+					} else {
+						displayName = dev.getName();
+					}
+					tv.setText(String.format("%s\n%s", displayName, dev.getAddress()));
 					return tv;
 				}
 			};


### PR DESCRIPTION
Closes #320.

## What this does
`BluetoothDevice.getName()` returns the name cached from the device's own advertisement, which doesn't update when the user renames an adapter in Android Bluetooth settings — so two adapters both advertising as "OBD II" stayed indistinguishable even after being given unique names.

On Android 11+ (API 30), `BluetoothDevice.getAlias()` returns the user-assigned alias if one exists. Uses it as the display name, falling back to `getName()` when no alias is set or on older devices. The MAC address was already shown on a second line, so this makes both lines accurate.

`BleDeviceListActivity` inherits this fix via `BtDeviceListActivity`.

`BLUETOOTH_CONNECT` is already checked/requested earlier in this activity before this code path runs, so no new permission handling needed. Builds clean (`assembleDebug`).