### PR TITLE
Migrate BtDeviceListActivity/DashBoardActivity/UsbDeviceListActivity/ChartActivity to AppCompatActivity

### DIFF
--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/BtDeviceListActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/BtDeviceListActivity.java
@@ -20,7 +20,6 @@ package com.fr3ts0n.ecu.gui.androbd;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
-import android.app.Activity;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.content.Context;
@@ -39,6 +38,7 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
 
 import java.util.ArrayList;
@@ -52,7 +52,7 @@ import java.util.logging.Logger;
  * by the user, the MAC address of the device is sent back to the parent
  * Activity in the result Intent.
  */
-public class BtDeviceListActivity extends Activity
+public class BtDeviceListActivity extends AppCompatActivity
 {
 	// Debugging
 	static final String TAG = BtDeviceListActivity.class.getSimpleName();
@@ -85,7 +85,7 @@ public class BtDeviceListActivity extends Activity
 		}
 
 		// Set result CANCELED in case the user backs out
-		setResult(Activity.RESULT_CANCELED);
+		setResult(RESULT_CANCELED);
 		// Setup the window
 		setContentView(R.layout.device_list);
 		
@@ -182,7 +182,7 @@ public class BtDeviceListActivity extends Activity
 			intent.putExtra(EXTRA_DEVICE_ADDRESS, address);
 
 			// Set result and finish this Activity
-			setResult(Activity.RESULT_OK, intent);
+			setResult(RESULT_OK, intent);
 			log.log(Level.FINE, "Sending Result...");
 			finish();
 		}

--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/ChartActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/ChartActivity.java
@@ -20,8 +20,6 @@ package com.fr3ts0n.ecu.gui.androbd;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
-import android.app.ActionBar;
-import android.app.Activity;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.graphics.Paint.Align;
@@ -38,6 +36,8 @@ import android.widget.EditText;
 import android.widget.ListAdapter;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
 
 import com.fr3ts0n.ecu.EcuDataPv;
@@ -62,7 +62,7 @@ import java.util.TreeSet;
  * passes in the number of the <code>Sensor</code>(s) to display. If none is
  * passed, the first available <code>Sensor</code> is used.
  */
-public class ChartActivity extends Activity
+public class ChartActivity extends AppCompatActivity
 {
 
 	/**
@@ -169,7 +169,7 @@ public class ChartActivity extends Activity
 		wakeLock.acquire();
 
 		// set up action bar
-		ActionBar actionBar = getActionBar();
+		ActionBar actionBar = getSupportActionBar();
 		if (actionBar != null)
 		{
 			actionBar.setDisplayShowTitleEnabled(true);
@@ -244,7 +244,7 @@ public class ChartActivity extends Activity
 			} else if (msg.what == MainActivity.MESSAGE_TOOLBAR_VISIBLE) {
 				Boolean visible = (Boolean) msg.obj;
 				// set action bar visibility
-				ActionBar ab = getActionBar();
+				ActionBar ab = getSupportActionBar();
 				if (ab != null) {
 					if (visible) {
 						ab.show();

--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/DashBoardActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/DashBoardActivity.java
@@ -18,8 +18,6 @@
 
 package com.fr3ts0n.ecu.gui.androbd;
 
-import android.app.ActionBar;
-import android.app.Activity;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
@@ -32,6 +30,9 @@ import android.view.WindowManager;
 import android.widget.AdapterView;
 import android.widget.GridView;
 import android.widget.ListAdapter;
+
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.fr3ts0n.ecu.EcuDataItem;
 import com.fr3ts0n.ecu.EcuDataItems;
@@ -48,7 +49,7 @@ import java.util.Objects;
 /**
  * Display selected data items as dashboard
  */
-public class DashBoardActivity extends Activity
+public class DashBoardActivity extends AppCompatActivity
 		implements PvChangeListener, AdapterView.OnItemLongClickListener
 {
 	/**
@@ -197,7 +198,7 @@ public class DashBoardActivity extends Activity
 			getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 		}
 		// hide the action bar
-		ActionBar actionBar = getActionBar();
+		ActionBar actionBar = getSupportActionBar();
 		if (actionBar != null) actionBar.hide();
 
 		// prevent activity from falling asleep

--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/UsbDeviceListActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/UsbDeviceListActivity.java
@@ -20,7 +20,6 @@
 package com.fr3ts0n.ecu.gui.androbd;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.hardware.usb.UsbDevice;
@@ -38,6 +37,8 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.TwoLineListItem;
 
+import androidx.appcompat.app.AppCompatActivity;
+
 import com.hoho.android.usbserial.driver.UsbSerialDriver;
 import com.hoho.android.usbserial.driver.UsbSerialPort;
 import com.hoho.android.usbserial.driver.UsbSerialProber;
@@ -53,7 +54,7 @@ import java.util.logging.Logger;
  *
  * @author mike wakerly (opensource@hoho.com)
  */
-public final class UsbDeviceListActivity extends Activity
+public final class UsbDeviceListActivity extends AppCompatActivity
 {
 	private static final String TAG = UsbDeviceListActivity.class.getSimpleName();
 	private static final Logger log = Logger.getLogger(TAG);
@@ -155,7 +156,7 @@ public final class UsbDeviceListActivity extends Activity
 				// Create the result Intent and include the MAC address
 				Intent intent = new Intent();
 				// Set result and finish this Activity
-				setResult(Activity.RESULT_OK, intent);
+				setResult(RESULT_OK, intent);
 				log.fine("Sending Result...");
 				finish();
 			}


### PR DESCRIPTION
Follow-up on #104's missing action bar.

Root cause: PR #335 added `Theme.Material3.*` but didn't touch any Activity class. Material3 is a Material Components/AppCompat theme — its action bar rendering is wired through `AppCompatActivity`'s window decor — but `BtDeviceListActivity`, `DashBoardActivity`, `UsbDeviceListActivity`, and `ChartActivity` all still extended plain `Activity`, so nothing rendered. This matches what you saw testing the merged Phase 1 PR.

Since the theme already uses the non-`.NoActionBar` variant (deliberately chosen in #335 to avoid layout changes), no manual `<Toolbar>` widgets are needed — the fix is just:
- `extends Activity` → `extends AppCompatActivity`
- `getActionBar()` → `getSupportActionBar()`
- `android.app.ActionBar` → `androidx.appcompat.app.ActionBar` import

`DashBoardActivity`'s existing action-bar-hide behaviour (fullscreen dashboard) and `ChartActivity`'s auto-hiding overlay toolbar (`AutoHider`) are both preserved unchanged — only the API calls they use were swapped.

**`MainActivity` is intentionally not included** — it extends `PluginManager` from the separate `AndrOBD-libplugin` submodule, which itself extends the deprecated `ListActivity`. That needs its own migration first; commented separately on #104 rather than guessing at scope for your other repo.

**Testing:** `./gradlew :androbd:assembleDebug` builds clean. I don't have OBD hardware to exercise these screens against a real vehicle/adapter — behaviour is otherwise unchanged, just the base class and action-bar API.