### PR TITLE
Phase 2 step 1: ProgressBar → CircularProgressIndicator in progress dialog (#104)

### DIFF
--- a/androbd/src/main/res/layout/modern_progress_dialog.xml
+++ b/androbd/src/main/res/layout/modern_progress_dialog.xml
@@ -16,9 +16,8 @@
         android:gravity="center"
         android:visibility="gone" />
 
-    <ProgressBar
+    <com.google.android.material.progressindicator.CircularProgressIndicator
         android:id="@+id/progress_bar"
-        style="?android:attr/progressBarStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="16dp"


### PR DESCRIPTION
Smallest possible first step of the Phase 2 GUI modernisation you gave the go-ahead for on #104.

`ModernProgressDialog`'s layout (`modern_progress_dialog.xml`) is the only place in the app using the plain `android.widget.ProgressBar`. Swapped for Material's `CircularProgressIndicator`, which has been a dependency since PR #335 (Phase 1 theme migration).

No Java changes needed — the widget is never referenced by ID in code, only shown as part of the dialog view as a whole, so this is a pure XML swap. Behaviour-identical (still indeterminate), just the modern Material look.

Build-verified with `assembleDebug`.

Cross-referenced on #104.