### PR TITLE
Settings: PreferenceActivity → PreferenceFragmentCompat (#104)

### DIFF
--- a/androbd/build.gradle
+++ b/androbd/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     implementation 'androidx.core:core:1.12.0'
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'com.google.android.material:material:1.12.0'
+    implementation 'androidx.preference:preference:1.2.1'
 
     // Local (JVM) unit tests
     testImplementation 'junit:junit:4.13.2'

--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/SearchableMultiSelectListPreference.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/SearchableMultiSelectListPreference.java
@@ -18,25 +18,18 @@
 
 package com.fr3ts0n.ecu.gui.androbd;
 
-import android.app.AlertDialog;
 import android.content.Context;
-import android.preference.MultiSelectListPreference;
-import android.text.Editable;
-import android.text.TextWatcher;
 import android.util.AttributeSet;
-import android.widget.ArrayAdapter;
-import android.widget.EditText;
-import android.widget.ListView;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
+import androidx.preference.MultiSelectListPreference;
 
 /**
  * Legacy-API compatible select all functionality for {@link MultiSelectListPreference}.
+ *
+ * <p>The custom "Select All" + search dialog UI itself lives in
+ * {@link SearchableMultiSelectListPreferenceDialogFragment} - AndroidX preference dialogs are
+ * shown via a {@code PreferenceDialogFragmentCompat}, not via an override on the Preference class
+ * itself, unlike the old {@code android.preference} API this was originally written against.
  *
  * @author BaderSZ
  */
@@ -54,130 +47,6 @@ public class SearchableMultiSelectListPreference extends MultiSelectListPreferen
 
     @SuppressWarnings("unused")
     public SearchableMultiSelectListPreference(Context context, AttributeSet attrs, int defStyle) {
-        super(context, attrs);
-    }
-
-    @SuppressWarnings("deprecation")
-    @Override
-    protected void onPrepareDialogBuilder(AlertDialog.Builder builder) {
-        CharSequence[] entries = getEntries();
-        CharSequence[] entryValues = getEntryValues();
-
-        if (entries == null || entryValues == null) {
-            super.onPrepareDialogBuilder(builder);
-            return;
-        }
-
-        // Add "Select All" at the top
-        final CharSequence[] items = new CharSequence[entries.length + 1];
-        final CharSequence[] values = new CharSequence[entryValues.length + 1];
-
-        items[0] = "Select All";
-        values[0] = "SELECT_ALL";
-
-        System.arraycopy(entries, 0, items, 1, entries.length);
-        System.arraycopy(entryValues, 0, values, 1, entryValues.length);
-
-        final Set<String> selectedValues = new HashSet<String>(getValues());
-        final boolean[] checkedItems = new boolean[items.length];
-
-        // Pre-check items
-        checkedItems[0] = selectedValues.size() == entryValues.length;
-        for (int i = 1; i < items.length; i++) {
-            checkedItems[i] = selectedValues.contains(values[i].toString());
-        }
-
-        final EditText search = new EditText(getContext());
-        search.setHint("Search...");
-
-        final ListView listView = new ListView(getContext());
-
-        final ArrayAdapter<CharSequence> adapter = new ArrayAdapter<CharSequence>(
-                getContext(),
-                android.R.layout.simple_list_item_multiple_choice,
-                new ArrayList<CharSequence>(Arrays.asList(items))
-        );
-        listView.setAdapter(adapter);
-        listView.setChoiceMode(ListView.CHOICE_MODE_MULTIPLE);
-
-        for (int i = 0; i < checkedItems.length; i++) {
-            listView.setItemChecked(i, checkedItems[i]);
-        }
-
-        search.addTextChangedListener(new TextWatcher() {
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-            }
-
-            public void onTextChanged(CharSequence s, int start, int before, int count) {
-            }
-
-            public void afterTextChanged(Editable s) {
-                String filter = s.toString().toLowerCase();
-
-                List<CharSequence> filteredItems = new ArrayList<CharSequence>();
-                // always keep "Select All" at top
-                filteredItems.add(items[0]);
-
-                // i=1 to skip "Select All"
-                for (int i = 1; i < items.length; i++) {
-                    if (items[i].toString().toLowerCase().contains(filter)) {
-                        filteredItems.add(items[i]);
-                    }
-                }
-
-                adapter.clear();
-                adapter.addAll(filteredItems);
-                adapter.notifyDataSetChanged();
-            }
-        });
-
-        listView.setOnItemClickListener((parent, view, position, id) -> {
-            CharSequence item = adapter.getItem(position);
-
-            int originalIndex = Arrays.asList(items).indexOf(item);
-            boolean isChecked = listView.isItemChecked(position);
-            checkedItems[originalIndex] = isChecked;
-
-            // Select All clicked.
-            if (originalIndex == 0) {
-                for (int i = 1; i < checkedItems.length; i++) {
-                    checkedItems[i] = isChecked;
-                    int filteredPos = adapter.getPosition(items[i]);
-                    if (filteredPos >= 0) listView.setItemChecked(filteredPos, isChecked);
-                }
-            } else {
-                boolean allChecked = true;
-                for (int i = 1; i < checkedItems.length; i++) {
-                    if (!checkedItems[i]) {
-                        allChecked = false;
-                        break;
-                    }
-                }
-                checkedItems[0] = allChecked;
-                int filteredPos = adapter.getPosition(items[0]);
-                if (filteredPos >= 0) listView.setItemChecked(filteredPos, allChecked);
-            }
-        });
-
-        android.widget.LinearLayout container = new android.widget.LinearLayout(getContext());
-        container.setOrientation(android.widget.LinearLayout.VERTICAL);
-        container.addView(search);
-        container.addView(listView);
-
-        builder.setView(container);
-
-        builder.setPositiveButton("OK", (dialog, which) -> {
-            Set<String> newValues = new HashSet<String>();
-            for (int i = 1; i < checkedItems.length; i++) {
-                if (checkedItems[i]) {
-                    newValues.add(values[i].toString());
-                }
-            }
-            if (callChangeListener(newValues)) {
-                setValues(newValues);
-            }
-        });
-
-        builder.setNegativeButton("Cancel", null);
+        super(context, attrs, defStyle);
     }
 }

--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/SearchableMultiSelectListPreferenceDialogFragment.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/SearchableMultiSelectListPreferenceDialogFragment.java
@@ -1,0 +1,202 @@
+/*
+ * (C) Copyright 2026 by Bader Zaidan <github@zaidan.tech>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+ * MA 02111-1307 USA
+ */
+
+package com.fr3ts0n.ecu.gui.androbd;
+
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.widget.ArrayAdapter;
+import android.widget.EditText;
+import android.widget.ListView;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.preference.PreferenceDialogFragmentCompat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * "Select All" + search dialog for {@link SearchableMultiSelectListPreference}.
+ *
+ * AndroidX shows preference dialogs through a {@code PreferenceDialogFragmentCompat}, so this
+ * carries the same custom {@code onPrepareDialogBuilder}/{@code onDialogClosed} logic the
+ * original {@code android.preference}-based class had directly on the Preference itself.
+ *
+ * @author BaderSZ
+ */
+public class SearchableMultiSelectListPreferenceDialogFragment
+        extends PreferenceDialogFragmentCompat {
+
+    private CharSequence[] entries;
+    private CharSequence[] entryValues;
+    private CharSequence[] items;
+    private CharSequence[] values;
+    private boolean[] checkedItems;
+
+    public static SearchableMultiSelectListPreferenceDialogFragment newInstance(String key) {
+        SearchableMultiSelectListPreferenceDialogFragment fragment =
+                new SearchableMultiSelectListPreferenceDialogFragment();
+        Bundle bundle = new Bundle(1);
+        bundle.putString(ARG_KEY, key);
+        fragment.setArguments(bundle);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        SearchableMultiSelectListPreference preference =
+                (SearchableMultiSelectListPreference) getPreference();
+        entries = preference.getEntries();
+        entryValues = preference.getEntryValues();
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    protected void onPrepareDialogBuilder(AlertDialog.Builder builder) {
+        if (entries == null || entryValues == null) {
+            return;
+        }
+
+        SearchableMultiSelectListPreference preference =
+                (SearchableMultiSelectListPreference) getPreference();
+
+        // Add "Select All" at the top
+        items = new CharSequence[entries.length + 1];
+        values = new CharSequence[entryValues.length + 1];
+
+        items[0] = "Select All";
+        values[0] = "SELECT_ALL";
+
+        System.arraycopy(entries, 0, items, 1, entries.length);
+        System.arraycopy(entryValues, 0, values, 1, entryValues.length);
+
+        final Set<String> selectedValues = new HashSet<>(preference.getValues());
+        checkedItems = new boolean[items.length];
+
+        // Pre-check items
+        checkedItems[0] = selectedValues.size() == entryValues.length;
+        for (int i = 1; i < items.length; i++) {
+            checkedItems[i] = selectedValues.contains(values[i].toString());
+        }
+
+        final EditText search = new EditText(getContext());
+        search.setHint("Search...");
+
+        final ListView listView = new ListView(getContext());
+
+        final ArrayAdapter<CharSequence> adapter = new ArrayAdapter<>(
+                getContext(),
+                android.R.layout.simple_list_item_multiple_choice,
+                new ArrayList<>(Arrays.asList(items))
+        );
+        listView.setAdapter(adapter);
+        listView.setChoiceMode(ListView.CHOICE_MODE_MULTIPLE);
+
+        for (int i = 0; i < checkedItems.length; i++) {
+            listView.setItemChecked(i, checkedItems[i]);
+        }
+
+        search.addTextChangedListener(new TextWatcher() {
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
+
+            public void afterTextChanged(Editable s) {
+                String filter = s.toString().toLowerCase();
+
+                List<CharSequence> filteredItems = new ArrayList<>();
+                // always keep "Select All" at top
+                filteredItems.add(items[0]);
+
+                // i=1 to skip "Select All"
+                for (int i = 1; i < items.length; i++) {
+                    if (items[i].toString().toLowerCase().contains(filter)) {
+                        filteredItems.add(items[i]);
+                    }
+                }
+
+                adapter.clear();
+                adapter.addAll(filteredItems);
+                adapter.notifyDataSetChanged();
+            }
+        });
+
+        listView.setOnItemClickListener((parent, view, position, id) -> {
+            CharSequence item = adapter.getItem(position);
+
+            int originalIndex = Arrays.asList(items).indexOf(item);
+            boolean isChecked = listView.isItemChecked(position);
+            checkedItems[originalIndex] = isChecked;
+
+            // Select All clicked.
+            if (originalIndex == 0) {
+                for (int i = 1; i < checkedItems.length; i++) {
+                    checkedItems[i] = isChecked;
+                    int filteredPos = adapter.getPosition(items[i]);
+                    if (filteredPos >= 0) listView.setItemChecked(filteredPos, isChecked);
+                }
+            } else {
+                boolean allChecked = true;
+                for (int i = 1; i < checkedItems.length; i++) {
+                    if (!checkedItems[i]) {
+                        allChecked = false;
+                        break;
+                    }
+                }
+                checkedItems[0] = allChecked;
+                int filteredPos = adapter.getPosition(items[0]);
+                if (filteredPos >= 0) listView.setItemChecked(filteredPos, allChecked);
+            }
+        });
+
+        android.widget.LinearLayout container = new android.widget.LinearLayout(getContext());
+        container.setOrientation(android.widget.LinearLayout.VERTICAL);
+        container.addView(search);
+        container.addView(listView);
+
+        builder.setView(container);
+        // The base PreferenceDialogFragmentCompat already supplies OK/Cancel buttons wired to
+        // onDialogClosed(); this dialog only needs to override the message/view area, not the
+        // buttons themselves - matching the effect of the original class's own
+        // setPositiveButton/setNegativeButton calls.
+    }
+
+    @Override
+    public void onDialogClosed(boolean positiveResult) {
+        if (positiveResult && items != null && values != null && checkedItems != null) {
+            SearchableMultiSelectListPreference preference =
+                    (SearchableMultiSelectListPreference) getPreference();
+            Set<String> newValues = new HashSet<>();
+            for (int i = 1; i < checkedItems.length; i++) {
+                if (checkedItems[i]) {
+                    newValues.add(values[i].toString());
+                }
+            }
+            if (preference.callChangeListener(newValues)) {
+                preference.setValues(newValues);
+            }
+        }
+    }
+}

--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/SettingsActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/SettingsActivity.java
@@ -29,13 +29,17 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
-import android.preference.EditTextPreference;
-import android.preference.ListPreference;
-import android.preference.MultiSelectListPreference;
-import android.preference.Preference;
-import android.preference.PreferenceActivity;
-import android.preference.PreferenceManager;
 import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.preference.EditTextPreference;
+import androidx.preference.ListPreference;
+import androidx.preference.MultiSelectListPreference;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.PreferenceManager;
 
 import java.util.Locale;
 
@@ -48,62 +52,22 @@ import java.util.Vector;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public class SettingsActivity
-	extends
-		PreferenceActivity
-	implements
-		SharedPreferences.OnSharedPreferenceChangeListener,
-		Preference.OnPreferenceClickListener
+public class SettingsActivity extends AppCompatActivity
 {
-	/** The logger object */
-	private static final Logger log = Logger.getLogger(SettingsActivity.class.getName());
-	
-	/**
-	 * app preferences
-	 */
-	private static SharedPreferences prefs;
-	/**
-	 * preference keys for extension files
-	 */
+	// Preference keys referenced from outside this class (MainActivity, ObdItemAdapter) -
+	// kept at this level, unlike the Settings-internal-only keys below, so those external
+	// call sites don't need to change.
 	static final String[] extKeys =
 	{
 		"ext_file_conversions",
 		"ext_file_dataitems"
 	};
-
-	/**
-	 * key ids for device network settings
-	 */
-	private static final String[] networkKeys =
-	{
-		"device_address",
-		"device_port"
-	};
-	/**
-	 * key ids for device network settings
-	 */
-	private static final String[] bluetoothKeys =
-	{
-		"bt_secure_connection"
-	};
-	/**
-	 * key ids for device network settings
-	 */
-	private static final String[] usbKeys =
-	{
-			"comm_baudrate"
-	};
-
-	// Preference key for data items
 	static final String KEY_DATA_ITEMS = "data_items";
 	static final String KEY_PROT_SELECT = "protocol";
 	static final String KEY_COMM_MEDIUM = "comm_medium";
 	static final String ELM_MIN_TIMEOUT = "elm_min_timeout";
 	static final String ELM_CMD_DISABLE = "elm_cmd_disable";
-    static final String ELM_TIMING_SELECT = "adaptive_timing_mode";
-    private static final String KEY_BITCOIN = "bitcoin";
-    private static final String KEY_OPEN_LOG_DIR = "open_log_dir";
-    static final String KEY_APP_LANGUAGE = "app_language";
+	private static final String KEY_APP_LANGUAGE = "app_language";
 
 	/**
 	 * Apply locale based on user preference
@@ -132,12 +96,6 @@ public class SettingsActivity
 		resources.updateConfiguration(config, resources.getDisplayMetrics());
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see android.preference.PreferenceActivity#onCreate(android.os.Bundle)
-	 */
-	Vector<EcuDataItem> items;
 	@Override
 	protected void onCreate(Bundle savedInstanceState)
 	{
@@ -145,32 +103,121 @@ public class SettingsActivity
 		applyLocale(this);
 		setTheme(MainActivity.nightMode ? R.style.AppTheme_Dark : R.style.AppTheme);
 		super.onCreate(savedInstanceState);
-		prefs = PreferenceManager.getDefaultSharedPreferences(this);
 
-		addPreferencesFromResource(R.xml.settings);
-
-		for (String key : extKeys)
+		if (savedInstanceState == null)
 		{
-			setPrefsText(key);
+			getSupportFragmentManager()
+				.beginTransaction()
+				.replace(android.R.id.content, new SettingsFragment())
+				.commit();
+		}
+	}
+
+	/**
+	 * The actual preference screen - AndroidX preference dialogs/screens are hosted in a
+	 * fragment rather than directly in an Activity, unlike the old {@code PreferenceActivity}
+	 * API this was originally written against.
+	 */
+	public static class SettingsFragment
+		extends
+			PreferenceFragmentCompat
+		implements
+			SharedPreferences.OnSharedPreferenceChangeListener,
+			Preference.OnPreferenceClickListener
+	{
+		/** The logger object */
+		private static final Logger log = Logger.getLogger(SettingsFragment.class.getName());
+
+		/**
+		 * app preferences
+		 */
+		private SharedPreferences prefs;
+
+		/**
+		 * key ids for device network settings
+		 */
+		private static final String[] networkKeys =
+		{
+			"device_address",
+			"device_port"
+		};
+		/**
+		 * key ids for device network settings
+		 */
+		private static final String[] bluetoothKeys =
+		{
+			"bt_secure_connection"
+		};
+		/**
+		 * key ids for device network settings
+		 */
+		private static final String[] usbKeys =
+		{
+				"comm_baudrate"
+		};
+
+		static final String ELM_TIMING_SELECT = "adaptive_timing_mode";
+		private static final String KEY_BITCOIN = "bitcoin";
+		private static final String KEY_OPEN_LOG_DIR = "open_log_dir";
+
+		Vector<EcuDataItem> items;
+
+		@Override
+		public void onCreatePreferences(@Nullable Bundle savedInstanceState, @Nullable String rootKey)
+		{
+			prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
+
+			setPreferencesFromResource(R.xml.settings, rootKey);
+
+			for (String key : extKeys)
+			{
+				setPrefsText(key);
+			}
+
+			// set up communication media selection
+			setupCommMediaSelection();
+			// set up protocol selection
+			setupProtoSelection();
+			// set up ELM command selection
+			setupElmCmdSelection();
+			// set up ELM adaptive timing mode selection
+			setupElmTimingSelection();
+			// set up selectable PID list
+			setupPidSelection();
+			// update network selection fields
+			updateNetworkSelections();
+			findPreference(KEY_BITCOIN).setOnPreferenceClickListener(this);
+			findPreference(KEY_OPEN_LOG_DIR).setOnPreferenceClickListener(this);
 		}
 
-		// set up communication media selection
-		setupCommMediaSelection();
-		// set up protocol selection
-		setupProtoSelection();
-		// set up ELM command selection
-		setupElmCmdSelection();
-		// set up ELM adaptive timing mode selection
-		setupElmTimingSelection();
-		// set up selectable PID list
-		setupPidSelection();
-		// update network selection fields
-		updateNetworkSelections();
-		findPreference(KEY_BITCOIN).setOnPreferenceClickListener(this);
-		findPreference(KEY_OPEN_LOG_DIR).setOnPreferenceClickListener(this);
-		// add handler for selection update
-		prefs.registerOnSharedPreferenceChangeListener(this);
-	}
+		@Override
+		public void onResume()
+		{
+			super.onResume();
+			// add handler for selection update
+			prefs.registerOnSharedPreferenceChangeListener(this);
+		}
+
+		@Override
+		public void onPause()
+		{
+			prefs.unregisterOnSharedPreferenceChangeListener(this);
+			super.onPause();
+		}
+
+		@Override
+		public void onDisplayPreferenceDialog(@NonNull Preference preference)
+		{
+			if (preference instanceof SearchableMultiSelectListPreference)
+			{
+				SearchableMultiSelectListPreferenceDialogFragment fragment =
+					SearchableMultiSelectListPreferenceDialogFragment.newInstance(preference.getKey());
+				fragment.setTargetFragment(this, 0);
+				fragment.show(getParentFragmentManager(), "androidx.preference.PreferenceFragment.DIALOG");
+				return;
+			}
+			super.onDisplayPreferenceDialog(preference);
+		}
 
 		/**
 		 * set up protocol selection
@@ -196,29 +243,29 @@ public class SettingsActivity
 			pref.setSummary(pref.getEntry());
 		}
 
-        /**
-         * set up protocol selection
-         */
-        void setupElmTimingSelection()
-        {
-            ListPreference pref = (ListPreference) findPreference(ELM_TIMING_SELECT);
-            ElmProt.AdaptTimingMode[] values = ElmProt.AdaptTimingMode.values();
-            CharSequence[] titles = new CharSequence[values.length];
-            CharSequence[] keys = new CharSequence[values.length];
-            int i = 0;
-            for (ElmProt.AdaptTimingMode mode : values)
-            {
+		/**
+		 * set up protocol selection
+		 */
+		void setupElmTimingSelection()
+		{
+			ListPreference pref = (ListPreference) findPreference(ELM_TIMING_SELECT);
+			ElmProt.AdaptTimingMode[] values = ElmProt.AdaptTimingMode.values();
+			CharSequence[] titles = new CharSequence[values.length];
+			CharSequence[] keys = new CharSequence[values.length];
+			int i = 0;
+			for (ElmProt.AdaptTimingMode mode : values)
+			{
 				titles[i] = mode.toString();
 				keys[i] = mode.toString();
 				i++;
-            }
-            // set entries and keys
-            pref.setEntries(titles);
-            pref.setEntryValues(keys);
-            pref.setDefaultValue(titles[0]);
-            // show current selection
-            pref.setSummary(pref.getEntry());
-        }
+			}
+			// set entries and keys
+			pref.setEntries(titles);
+			pref.setEntryValues(keys);
+			pref.setDefaultValue(titles[0]);
+			// show current selection
+			pref.setSummary(pref.getEntry());
+		}
 
 		/**
 		 * set up protocol selection
@@ -361,10 +408,10 @@ public class SettingsActivity
 		private void openLogDirectory()
 		{
 			java.io.File logDir = new java.io.File(
-					FileHelper.getPath(this), "log");
+					FileHelper.getPath(requireContext()), "log");
 			if (!logDir.isDirectory())
 			{
-				Toast.makeText(this,
+				Toast.makeText(requireContext(),
 						R.string.log_dir_not_found,
 						Toast.LENGTH_LONG).show();
 				return;
@@ -382,10 +429,10 @@ public class SettingsActivity
 				// No file manager installed, or Android 7+ blocked file:// URI;
 				// copy the path to clipboard as a fallback.
 				ClipboardManager cm = (ClipboardManager)
-						getSystemService(CLIPBOARD_SERVICE);
+						requireContext().getSystemService(CLIPBOARD_SERVICE);
 				cm.setPrimaryClip(ClipData.newPlainText(
 						"log_dir", logDir.getAbsolutePath()));
-				Toast.makeText(this,
+				Toast.makeText(requireContext(),
 						R.string.log_dir_no_app,
 						Toast.LENGTH_LONG).show();
 			}
@@ -417,7 +464,7 @@ public class SettingsActivity
 			catch(Exception e)
 			{
 				log.log(Level.SEVERE, "Settings", e);
-				Toast.makeText(this, e.getMessage(), Toast.LENGTH_LONG).show();
+				Toast.makeText(requireContext(), e.getMessage(), Toast.LENGTH_LONG).show();
 			}
 			return true;
 		}
@@ -475,12 +522,13 @@ public class SettingsActivity
 			if(KEY_APP_LANGUAGE.equals(key))
 			{
 				// Apply new language immediately
-				applyLocale(this);
+				SettingsActivity.applyLocale(requireActivity());
 
 				// Show restart message
-				Toast.makeText(this,
+				Toast.makeText(requireContext(),
 				              getString(R.string.restart_required),
 				              Toast.LENGTH_LONG).show();
 			}
 		}
 	}
+}


### PR DESCRIPTION
Next item in the Phase 2 GUI modernisation order you gave the go-ahead for on #104.

`SettingsActivity` extended the deprecated `android.preference.PreferenceActivity` (deprecated since API 28). Restructured into a thin `AppCompatActivity` hosting a new `SettingsFragment extends PreferenceFragmentCompat`.

Six preference keys are referenced externally by `MainActivity`/`ObdItemAdapter` (`KEY_DATA_ITEMS`, `KEY_PROT_SELECT`, `KEY_COMM_MEDIUM`, `ELM_MIN_TIMEOUT`, `ELM_CMD_DISABLE`, `extKeys`) — kept on the outer `SettingsActivity` class rather than moved into the fragment, so those call sites needed no changes.

`SearchableMultiSelectListPreference` (the custom "Select All" + search dialog used for the PID selection list) also needed migrating: AndroidX shows preference dialogs via a `PreferenceDialogFragmentCompat` rather than an override directly on the Preference class, unlike the old API. Moved the dialog-building logic into a new `SearchableMultiSelectListPreferenceDialogFragment`, wired up via `SettingsFragment.onDisplayPreferenceDialog`. Behaviour (search filter, Select All toggle, pre-checked state) is unchanged.

Added `androidx.preference:preference:1.2.1` (not previously a dependency).

`startActivityForResult`/`onActivityResult` deliberately left as-is on the fragment (deprecated but functional) — out of scope for this specific deprecation fix.

**Testing:** `./gradlew :androbd:assembleDebug` and `./gradlew :androbd:testDebugUnitTest` both pass. I don't have OBD hardware to exercise these screens against a real vehicle/adapter — behaviour is otherwise unchanged, just the underlying preference API.

Cross-referenced on #104.