### PR TITLE
fix: wire up nested PreferenceScreen navigation in SettingsActivity

### DIFF
--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/SettingsActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/SettingsActivity.java
@@ -29,11 +29,15 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
+import android.view.View;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.preference.EditTextPreference;
 import androidx.preference.ListPreference;
 import androidx.preference.MultiSelectListPreference;
@@ -210,8 +214,85 @@ public class SettingsActivity extends AppCompatActivity
 			setupPidSelection();
 			// update network selection fields
 			updateNetworkSelections();
-			findPreference(KEY_BITCOIN).setOnPreferenceClickListener(this);
-			findPreference(KEY_OPEN_LOG_DIR).setOnPreferenceClickListener(this);
+			setPrefClickListener(KEY_BITCOIN);
+			setPrefClickListener(KEY_OPEN_LOG_DIR);
+		}
+
+		/**
+		 * Each time a nested PreferenceScreen is entered or backed out of, this fragment's
+		 * view is destroyed and a new one created (FragmentTransaction.replace()). Something
+		 * in the framework/AppCompat already positions list_container correctly below the
+		 * status bar and action bar for a freshly created fragment - but that mechanism
+		 * doesn't reliably re-run for every (re)created instance, occasionally leaving
+		 * list_container at y=0, rendered under the status bar and action bar. Only patch
+		 * it when that's actually happened (current position is at/near the top) - the
+		 * expected offset is already correct far more often than not, and blindly adding
+		 * padding regardless would double it up on top of whatever positioned it correctly
+		 * in the first place. Posted rather than applied inline, both so the view has a
+		 * real on-screen position to check yet, and so the action bar has its final
+		 * measured height.
+		 */
+		@Override
+		public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState)
+		{
+			super.onViewCreated(view, savedInstanceState);
+			view.post(() -> fixUnpaddedListContainer(view));
+		}
+
+		private void fixUnpaddedListContainer(@NonNull View fragmentView)
+		{
+			View listContainer = fragmentView.findViewById(android.R.id.list_container);
+			if (listContainer == null) return;
+
+			int statusBarHeight = 0;
+			WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(fragmentView);
+			if (insets != null)
+			{
+				statusBarHeight = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top;
+			}
+
+			int actionBarHeight = 0;
+			if (requireActivity() instanceof AppCompatActivity)
+			{
+				ActionBar actionBar = ((AppCompatActivity) requireActivity()).getSupportActionBar();
+				if (actionBar != null)
+				{
+					actionBarHeight = actionBar.getHeight();
+				}
+			}
+			int expectedTop = statusBarHeight + actionBarHeight;
+
+			int[] screenLocation = new int[2];
+			listContainer.getLocationOnScreen(screenLocation);
+			int actualTop = screenLocation[1];
+
+			// Comfortably below "unpadded" (0) but still well short of the correct offset -
+			// avoids both a false negative from minor measurement variance and a false
+			// positive that would double-pad an already-correct layout.
+			if (actualTop < statusBarHeight)
+			{
+				listContainer.setPadding(
+					listContainer.getPaddingLeft(),
+					listContainer.getPaddingTop() + (expectedTop - actualTop),
+					listContainer.getPaddingRight(),
+					listContainer.getPaddingBottom());
+			}
+		}
+
+		/**
+		 * Set this fragment as the click listener for a preference, if it exists in the
+		 * currently displayed (sub-)screen. findPreference() only searches the tree rooted
+		 * at whichever screen setPreferencesFromResource() was given - a key that lives in
+		 * a different top-level PreferenceScreen won't be found, which is expected rather
+		 * than an error.
+		 */
+		private void setPrefClickListener(String key)
+		{
+			Preference pref = findPreference(key);
+			if (pref != null)
+			{
+				pref.setOnPreferenceClickListener(this);
+			}
 		}
 
 		@Override
@@ -249,6 +330,7 @@ public class SettingsActivity extends AppCompatActivity
 		void setupProtoSelection()
 		{
 			ListPreference pref = (ListPreference) findPreference(KEY_PROT_SELECT);
+			if (pref == null) return;
 			ElmProt.PROT[] values = ElmProt.PROT.values();
 			CharSequence[] titles = new CharSequence[values.length];
 			CharSequence[] keys = new CharSequence[values.length];
@@ -273,6 +355,7 @@ public class SettingsActivity extends AppCompatActivity
 		void setupElmTimingSelection()
 		{
 			ListPreference pref = (ListPreference) findPreference(ELM_TIMING_SELECT);
+			if (pref == null) return;
 			ElmProt.AdaptTimingMode[] values = ElmProt.AdaptTimingMode.values();
 			CharSequence[] titles = new CharSequence[values.length];
 			CharSequence[] keys = new CharSequence[values.length];
@@ -298,6 +381,7 @@ public class SettingsActivity extends AppCompatActivity
 		{
 			MultiSelectListPreference pref =
 				(MultiSelectListPreference) findPreference(ELM_CMD_DISABLE);
+			if (pref == null) return;
 			ElmProt.CMD[] values = ElmProt.CMD.values();
 			HashSet<String> selections = new HashSet<>();
 			CharSequence[] titles = new CharSequence[values.length];
@@ -322,6 +406,7 @@ public class SettingsActivity extends AppCompatActivity
 		void setupCommMediaSelection()
 		{
 			ListPreference pref = (ListPreference) findPreference(KEY_COMM_MEDIUM);
+			if (pref == null) return;
 			CommService.MEDIUM[] values = CommService.MEDIUM.values();
 			CharSequence[] titles = new CharSequence[values.length];
 			CharSequence[] keys = new CharSequence[values.length];
@@ -347,6 +432,7 @@ public class SettingsActivity extends AppCompatActivity
 		{
 			SearchableMultiSelectListPreference itemList =
 				(SearchableMultiSelectListPreference) findPreference(KEY_DATA_ITEMS);
+			if (itemList == null) return;
 
 			// collect data items for selection
 			items = ObdProt.dataItems.getSvcDataItems(ObdProt.OBD_SVC_DATA);
@@ -381,6 +467,7 @@ public class SettingsActivity extends AppCompatActivity
 		void setPrefsText(String key)
 		{
 			Preference prefComp = findPreference(key);
+			if (prefComp == null) return;
 			prefComp.setOnPreferenceClickListener(this);
 			String value = prefs.getString(key, null);
 			if (value != null)
@@ -411,21 +498,21 @@ public class SettingsActivity extends AppCompatActivity
 			for(String key : networkKeys)
 			{
 				Preference pref = findPreference(key);
-				pref.setEnabled(networkSelected);
+				if (pref != null) pref.setEnabled(networkSelected);
 			}
 
 			// enable/disable bluetooth specific entries
 			for(String key : bluetoothKeys)
 			{
 				Preference pref = findPreference(key);
-				pref.setEnabled(bluetoothSelected);
+				if (pref != null) pref.setEnabled(bluetoothSelected);
 			}
 
 			// enable/disable usb specific entries
 			for(String key : usbKeys)
 			{
 				Preference pref = findPreference(key);
-				pref.setEnabled(usbSelected);
+				if (pref != null) pref.setEnabled(usbSelected);
 			}
 		}
 

--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/SettingsActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/SettingsActivity.java
@@ -40,6 +40,7 @@ import androidx.preference.MultiSelectListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceManager;
+import androidx.preference.PreferenceScreen;
 
 import java.util.Locale;
 
@@ -53,6 +54,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class SettingsActivity extends AppCompatActivity
+	implements PreferenceFragmentCompat.OnPreferenceStartScreenCallback
 {
 	// Preference keys referenced from outside this class (MainActivity, ObdItemAdapter) -
 	// kept at this level, unlike the Settings-internal-only keys below, so those external
@@ -111,6 +113,28 @@ public class SettingsActivity extends AppCompatActivity
 				.replace(android.R.id.content, new SettingsFragment())
 				.commit();
 		}
+	}
+
+	/**
+	 * Called when the user taps a nested {@code PreferenceScreen} (e.g. "OBD Options",
+	 * "CSV Export Options"). AndroidX Preference does not navigate to sub-screens on its
+	 * own - the hosting activity has to swap in a new {@link SettingsFragment} rooted at
+	 * the tapped screen's key, or the tap silently does nothing.
+	 */
+	@Override
+	public boolean onPreferenceStartScreen(PreferenceFragmentCompat caller, PreferenceScreen pref)
+	{
+		SettingsFragment fragment = new SettingsFragment();
+		Bundle args = new Bundle();
+		args.putString(PreferenceFragmentCompat.ARG_PREFERENCE_ROOT, pref.getKey());
+		fragment.setArguments(args);
+
+		getSupportFragmentManager()
+			.beginTransaction()
+			.replace(android.R.id.content, fragment)
+			.addToBackStack(pref.getKey())
+			.commit();
+		return true;
 	}
 
 	/**

--- a/androbd/src/main/res/xml/settings.xml
+++ b/androbd/src/main/res/xml/settings.xml
@@ -4,6 +4,7 @@
                   android:title="@string/settings">
 
     <PreferenceScreen
+        android:key="screen_common_settings"
         android:icon="@android:drawable/ic_menu_manage"
         android:summary="@string/common_settings_description"
         android:title="@string/common_settings">
@@ -92,6 +93,7 @@
 
 
     <PreferenceScreen
+        android:key="screen_obd_options"
         android:icon="@android:drawable/ic_menu_manage"
         android:summary="@string/obd_opt_description"
         android:title="@string/obd_options">
@@ -213,6 +215,7 @@
     </PreferenceScreen>
 
     <PreferenceScreen
+        android:key="screen_csv_export_options"
         android:icon="@android:drawable/ic_menu_save"
         android:summary="@string/csv_export_description"
         android:title="@string/csv_export_options"
@@ -254,6 +257,7 @@
     </PreferenceScreen>
 
     <PreferenceScreen
+        android:key="screen_development_options"
         android:icon="@android:drawable/ic_menu_manage"
         android:summary="@string/dev_opt_description"
         android:title="@string/development_options"
@@ -322,6 +326,7 @@
     </PreferenceScreen>
 
     <PreferenceScreen
+        android:key="screen_app_info"
         android:icon="@android:drawable/ic_menu_info_details"
         android:summary="@string/app_version"
         android:title="@string/app_name"
@@ -362,6 +367,7 @@
                 android:data="@string/url_app_translation"/>
         </Preference>
         <PreferenceScreen
+            android:key="screen_license"
             android:icon="@drawable/ic_scale"
             android:title="@string/license"
             >


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change that resolves an issue)

## What this fixes

Regression in #344 reported on #104: tapping any of the top-level setting groups (Common Settings, OBD Options, CSV Export, Development Options, App info) showed the group list but selecting one opened nothing.

Root cause: AndroidX Preference does not auto-navigate into nested `PreferenceScreen`s the way the old `PreferenceActivity`/headers API did. The hosting activity has to implement `PreferenceFragmentCompat.OnPreferenceStartScreenCallback` and swap in a new fragment rooted at the tapped screen's key, or the tap silently does nothing. `settings.xml`'s nested `PreferenceScreen` elements also had no `android:key`, so even a correct callback would have had nothing to root the sub-fragment on.

Testing this on-device surfaced two further bugs in the same code path, both fixed here too:
- **NPE crash** entering any nested screen: `onCreatePreferences()` unconditionally looked up preferences from every screen regardless of which (sub-)tree is actually loaded, but `findPreference()` only searches the currently-set screen and its descendants. Guarded each lookup so setup that doesn't apply to the current screen is skipped rather than crashing.
- **Layout glitch**: after backing out of a nested screen, the list rendered from y=0, under the status bar and action bar, because the mechanism that positions a freshly created fragment's `list_container` doesn't reliably re-run for every (re)created instance. Detects this specific case and corrects the padding directly, without touching fragments where it's already correct.

## Changes
- Added `android:key` to each of the 6 nested `PreferenceScreen` elements in `settings.xml` (Common Settings, OBD Options, CSV Export Options, Development Options, App info, and the nested License screen).
- Implemented `OnPreferenceStartScreenCallback` on `SettingsActivity`: creates a new `SettingsFragment` with `PreferenceFragmentCompat.ARG_PREFERENCE_ROOT` set to the tapped screen's key, and pushes it via a fragment transaction with `addToBackStack`. System back button already pops the fragment back stack via `FragmentActivity`'s default `onBackPressed()`.
- Guarded every `findPreference()`-dependent setup call in `SettingsFragment` against the key not existing in the currently displayed screen.
- Added an `onViewCreated()` check that detects an unpadded `list_container` (rendered under the status bar/action bar) and corrects it, without affecting screens that are already positioned correctly.

## Testing
- `./gradlew :androbd:compileDebugJavaWithJavac` — clean
- `./gradlew :androbd:testDebugUnitTest` — all pass
- Verified on-device (Pixel 10, Android 16): all 5 top-level groups plus the nested License screen open correctly; back navigation restores correct layout at every depth (tested 3 levels deep: Settings → App info → License); no crashes.

## Notes
- Cross-referenced on #104.