### PR TITLE
feat: enable R8/resource shrinking for release builds (#339)

### DIFF
--- a/androbd/build.gradle
+++ b/androbd/build.gradle
@@ -32,6 +32,14 @@ android {
         // remove this line.
         abortOnError false
     }
+
+    buildTypes {
+        release {
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
 }
 
 dependencies {

--- a/androbd/proguard-rules.pro
+++ b/androbd/proguard-rules.pro
@@ -2,15 +2,30 @@
 # For more details, see
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
-# PvXMLHandler reconstructs saved ProcessVar objects by fully-qualified class
-# name (PvXMLWriter writes pv.getClass().getName() as the XML "type"
-# attribute, PvXMLHandler reads it back via Class.forName(...).newInstance()).
-# Keep the whole hierarchy - including any future subclasses - and the
-# no-arg constructor that reflection needs, or saved PV files fail to load
-# after R8 renames/removes these classes. See issue #339.
+# The Save/Load menu items (MainActivity -> FileHelper.saveData/loadData)
+# serialize live ProcessVar objects (ObdProt.PidPvs/VidPvs/tCodes,
+# MainActivity.mPluginPvs) with plain Java serialization (ObjectOutputStream).
+# Deserialization matches by class name, so keep the whole hierarchy -
+# including any future subclasses - and the no-arg constructor, or a
+# previously-saved file fails to load after R8 renames these classes.
+# (PvXMLHandler's own reflective Class.forName() load path is dead code on
+# Android - only reachable from its own standalone main(), never called by
+# the app - so it's not actually what's at risk here, despite the obvious
+# first guess. See issue #339 / roadmap for the full trace.)
 -keep class com.fr3ts0n.pvs.ProcessVar {
     public <init>();
 }
 -keep class * extends com.fr3ts0n.pvs.ProcessVar {
     public <init>();
 }
+
+# R8's default class repackaging moves classes into the root package, which
+# breaks any *relative* Class.getResource()/getResourceAsStream() call -
+# EcuDataItems.loadFromResource() does exactly this
+# (getClass().getResource("prot/obd/res/pids.csv")), and the resource file
+# itself is untouched (present in the APK either way) but the lookup path
+# no longer matches once the class moves. Crashed on every launch of the
+# first R8-shrunk build (NullPointerException in ObdProt's static
+# initializer). Keeping package names avoids this whole bug class for any
+# current or future relative-resource lookup, at negligible size cost.
+-keeppackagenames

--- a/androbd/proguard-rules.pro
+++ b/androbd/proguard-rules.pro
@@ -1,0 +1,16 @@
+# Add project specific ProGuard rules here.
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# PvXMLHandler reconstructs saved ProcessVar objects by fully-qualified class
+# name (PvXMLWriter writes pv.getClass().getName() as the XML "type"
+# attribute, PvXMLHandler reads it back via Class.forName(...).newInstance()).
+# Keep the whole hierarchy - including any future subclasses - and the
+# no-arg constructor that reflection needs, or saved PV files fail to load
+# after R8 renames/removes these classes. See issue #339.
+-keep class com.fr3ts0n.pvs.ProcessVar {
+    public <init>();
+}
+-keep class * extends com.fr3ts0n.pvs.ProcessVar {
+    public <init>();
+}


### PR DESCRIPTION
## Type of change
- [x] New feature (non-breaking change that adds functionality)

## What this fixes

Closes #339. No `buildTypes` block existed at all, so the release APK carried the full unshrunk weight of the AppCompat/Material dependencies added in #104/#335 — this sets up R8 shrinking to reclaim that.

## Changes
- Added a `release` `buildTypes` block: `minifyEnabled true`, `shrinkResources true`.
- Added a keep rule for the `ProcessVar` hierarchy (`ProcessVar`, `PvList`, `DbProcessVar`, `EcuCodeItem`, `EcuDataPv`, `ObdVidItem`) and its no-arg constructors. The Save/Load menu items (`FileHelper.saveData()`/`loadData()`) serialize these directly with `ObjectOutputStream`, and deserialization matches by class name — without this, R8 renaming breaks loading a previously-saved file.
- Added `-keeppackagenames`. First real device test crashed on every single launch: R8's default class repackaging moved `EcuDataItems` into the unnamed root package, which broke `EcuDataItems.loadFromResource()`'s relative `getClass().getResource("prot/obd/res/pids.csv")` lookup (relative `getResource()` calls resolve against the class's own package at runtime). The resource file itself was never touched — confirmed present, unchanged, in both the debug and release APKs — this was a repackaging problem, not a resource-shrinking one. `-keeppackagenames` stops the repackaging without giving up class/member renaming or code shrinking.

## Testing
- `./gradlew :androbd:testDebugUnitTest` — all pass
- `./gradlew :androbd:assembleDebug` — clean, unaffected (minification is release-only)
- `./gradlew :androbd:assembleRelease` — `minifyReleaseWithR8` succeeds, zero missing-class errors
- Unsigned release APK size: **5.70MB → 2.30MB**
- Verified on-device (Pixel 10, Android 16): signed the release build with the debug keystore for local testing, installed, launched — clean, no crash (the pre-`-keeppackagenames` build crashed on every launch). Connected to a simulated ECU, used the real Save measurement / Load measurement menu items: saved 1159 bytes, reloaded the same file, confirmed via logcat — no `ClassNotFoundException`/`InvalidClassException`/`StreamCorruptedException`, the actual serialization round trip the keep rule exists to protect.

## Notes
- Cross-referenced on #339.
