### PR TITLE
fix: cap home-screen logo size instead of stretching to fill (#102)

### DIFF
--- a/androbd/src/main/res/layout/startup_layout.xml
+++ b/androbd/src/main/res/layout/startup_layout.xml
@@ -5,14 +5,23 @@
     android:orientation="vertical"
     >
 
-    <ImageView
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
         android:background="#20FFFFFF"
-        android:contentDescription="@string/logo"
-        android:padding="@dimen/activity_horizontal_margin"
-        android:src="@drawable/logo"/>
+        android:gravity="center">
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:adjustViewBounds="true"
+            android:maxWidth="240dp"
+            android:maxHeight="240dp"
+            android:contentDescription="@string/logo"
+            android:padding="@dimen/activity_horizontal_margin"
+            android:src="@drawable/logo"/>
+    </LinearLayout>
 
     <LinearLayout
         android:orientation="vertical"


### PR DESCRIPTION
Fixes #102.

The home-screen logo (`startup_layout.xml`) was a plain `ImageView` set to `match_parent` width and `layout_weight="1"` height — meaning the 192x145px source (`drawable/logo.png`) was stretched to fill roughly the whole top half of the screen on a typical phone, an upscale of 5-7x, which is what produces the blurry edges reported.

Wrapped the `ImageView` in a centered `LinearLayout` (keeping the same light background/region) and capped the image itself to `maxWidth`/`maxHeight="240dp"` with `adjustViewBounds="true"`, so it renders at a sensible size instead of being stretched to fill available space. Directly addresses both parts of the report ("a little smaller" and "more sharp") without touching the artwork itself — there's no vector/higher-res source for this specific mark in the repo (the launcher icon's foreground layer is the same design but white-on-transparent, meant for the purple adaptive-icon background, not a drop-in replacement for this light-background context), so a genuine resolution bump would need the original design files linked in the issue thread, which is outside what a source-only PR can do.

Verified on-device (Pixel 10): before/after comparison confirms the logo now renders centred at a fixed, reasonable size instead of filling the screen.

## PR checklist
- [x] Builds clean (`assembleDebug`, `lintDebug`)
- [x] No behaviour change — layout-only, home screen still shows the same logo/links
- [x] Verified on-device (Pixel 10)
- [x] No new dependencies

AI disclosure: drafted with Claude Code assistance; reasoning and diff reviewed before opening.