### PR TITLE
Follow system theme via AppCompatDelegate (fixes #128)

### DIFF
--- a/androbd/src/main/AndroidManifest.xml
+++ b/androbd/src/main/AndroidManifest.xml
@@ -37,7 +37,8 @@
         android:description="@string/app_description"
         android:fullBackupContent="true"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name">
+        android:label="@string/app_name"
+        android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"

--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/BtDeviceListActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/BtDeviceListActivity.java
@@ -68,7 +68,6 @@ public class BtDeviceListActivity extends AppCompatActivity
 	@Override
 	protected void onCreate(Bundle savedInstanceState)
 	{
-		setTheme(MainActivity.nightMode ? R.style.AppTheme_Dark : R.style.AppTheme);
 		super.onCreate(savedInstanceState);
 
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/ChartActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/ChartActivity.java
@@ -150,7 +150,6 @@ public class ChartActivity extends AppCompatActivity
 	{
 		// Apply locale before anything else
 		SettingsActivity.applyLocale(this);
-		setTheme(MainActivity.nightMode ? R.style.AppTheme_Dark : R.style.AppTheme);
 
 		super.onCreate(savedInstanceState);
 		getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,

--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/DashBoardActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/DashBoardActivity.java
@@ -186,7 +186,6 @@ public class DashBoardActivity extends AppCompatActivity
 	{
 		// Apply locale before anything else
 		SettingsActivity.applyLocale(this);
-		setTheme(MainActivity.nightMode ? R.style.AppTheme_Dark : R.style.AppTheme);
 
 		super.onCreate(savedInstanceState);
 		// set to full screen

--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/MainActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/MainActivity.java
@@ -37,6 +37,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
@@ -63,6 +64,7 @@ import android.widget.Spinner;
 import android.widget.Toast;
 import android.window.OnBackInvokedCallback;
 
+import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.FileProvider;
 
@@ -143,7 +145,10 @@ public class MainActivity extends PluginManager
     private static final String DEVICE_ADDRESS = "device_address";
     private static final String DEVICE_PORT = "device_port";
     private static final String MEASURE_SYSTEM = "measure_system";
+    /** legacy boolean preference key, kept only to migrate existing users' choice */
     private static final String NIGHT_MODE = "night_mode";
+    /** tri-state theme preference key: "system", "light" or "dark" */
+    private static final String THEME_MODE = "theme_mode";
     private static final String ELM_ADAPTIVE_TIMING = "adaptive_timing_mode";
     private static final String ELM_RESET_ON_NRC = "elm_reset_on_nrc";
     private static final String PREF_USE_LAST = "USE_LAST_SETTINGS";
@@ -196,10 +201,6 @@ public class MainActivity extends PluginManager
      * Container for Plugin-provided data
      */
     public static PvList mPluginPvs = new PvList();
-    /**
-     * current status of night mode
-     */
-    public static boolean nightMode = false;
     /**
      * app preferences ...
      */
@@ -546,7 +547,7 @@ public class MainActivity extends PluginManager
 
         // get preferences
         prefs = PreferenceManager.getDefaultSharedPreferences(this);
-        setNightMode(prefs.getBoolean(NIGHT_MODE, false));
+        applyThemeMode(false);
 
         // instantiate superclass
         super.onCreate(savedInstanceState);
@@ -945,8 +946,10 @@ public class MainActivity extends PluginManager
         {
             // Display and UI Management
             if(id == R.id.day_night_mode) {
-                // toggle night mode setting
-                prefs.edit().putBoolean(NIGHT_MODE, !nightMode).apply();
+                // quick toggle: force the opposite of what's currently displayed
+                boolean currentlyDark = (getResources().getConfiguration().uiMode
+                        & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
+                prefs.edit().putString(THEME_MODE, currentlyDark ? "light" : "dark").apply();
                 return true;
             }
 
@@ -1212,10 +1215,10 @@ public class MainActivity extends PluginManager
                     WindowManager.LayoutParams.FLAG_FULLSCREEN);
         }
 
-        // night mode
-        if (key == null || NIGHT_MODE.equals(key))
+        // theme (day/night) mode
+        if (key == null || THEME_MODE.equals(key))
         {
-            setNightMode(prefs.getBoolean(NIGHT_MODE, false));
+            applyThemeMode(true);
         }
 
         // set default comm medium
@@ -1671,14 +1674,54 @@ public class MainActivity extends PluginManager
         }
     }
 
-    protected void setNightMode(boolean nightMode)
+    /**
+     * Read the tri-state theme preference, migrating the old boolean night_mode
+     * preference on first read for users upgrading from an earlier version.
+     */
+    static String getThemeModePref(SharedPreferences prefs)
     {
-        // store last mode selection
-        MainActivity.nightMode = nightMode;
+        if (prefs.contains(THEME_MODE))
+        {
+            return prefs.getString(THEME_MODE, "system");
+        }
+        if (prefs.contains(NIGHT_MODE))
+        {
+            String migrated = prefs.getBoolean(NIGHT_MODE, false) ? "dark" : "light";
+            prefs.edit().putString(THEME_MODE, migrated).remove(NIGHT_MODE).apply();
+            return migrated;
+        }
+        return "system";
+    }
 
-        // Set display theme based on specified mode
-        setTheme(nightMode ? R.style.AppTheme_Dark : R.style.AppTheme);
-        getWindow().getDecorView().setBackgroundColor(nightMode ? Color.BLACK : Color.WHITE);
+    static int themeModeToNightMode(String themeMode)
+    {
+        switch (themeMode)
+        {
+            case "dark":
+                return AppCompatDelegate.MODE_NIGHT_YES;
+            case "light":
+                return AppCompatDelegate.MODE_NIGHT_NO;
+            default:
+                return AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM;
+        }
+    }
+
+    /**
+     * Apply the tri-state theme preference application-wide via AppCompatDelegate.
+     * MainActivity itself isn't an AppCompatActivity (it extends the legacy
+     * ListActivity via PluginManager), so a live preference change needs an
+     * explicit recreate() here to pick up the new theme; other activities in
+     * this app are AppCompatActivity subclasses and re-theme automatically.
+     */
+    private void applyThemeMode(boolean recreateIfChanged)
+    {
+        int wanted = themeModeToNightMode(getThemeModePref(prefs));
+        boolean changed = AppCompatDelegate.getDefaultNightMode() != wanted;
+        AppCompatDelegate.setDefaultNightMode(wanted);
+        if (changed && recreateIfChanged)
+        {
+            recreate();
+        }
     }
 
     private void setNumCodes(int newNumCodes)

--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/SettingsActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/SettingsActivity.java
@@ -107,7 +107,6 @@ public class SettingsActivity extends AppCompatActivity
 	{
 		// Apply locale before calling super.onCreate()
 		applyLocale(this);
-		setTheme(MainActivity.nightMode ? R.style.AppTheme_Dark : R.style.AppTheme);
 		super.onCreate(savedInstanceState);
 
 		if (savedInstanceState == null)

--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/UsbDeviceListActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/UsbDeviceListActivity.java
@@ -92,7 +92,6 @@ public final class UsbDeviceListActivity extends AppCompatActivity
 	@Override
 	public void onCreate(Bundle savedInstanceState)
 	{
-		setTheme(MainActivity.nightMode ? R.style.AppTheme_Dark : R.style.AppTheme);
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.usb_list);
 

--- a/androbd/src/main/res/values-am/strings.xml
+++ b/androbd/src/main/res/values-am/strings.xml
@@ -86,7 +86,6 @@
     <string name="elm_adaptive_timing_descr">Allow adaptive timing handling in ELM drivers\?</string>
     <string name="obd_error">OBD ፕሮትኮል ችግር ተፈጥርዋል</string>
     <string name="back_again_to_exit">ለመዝጋት ተመለስ የሚለውን ቁልፍ ይጫኑ</string>
-    <string name="night_mode_description">እይታውን በዳርክ ባክግራውንድ ቀይር</string>
     <string name="license">ፈቃድ …</string>
     <string name="BUSERROR">የ BUS ችግር ተፈጥርዋል</string>
     <string name="extension_files">ፕሮቶኮል ማስተካከያ ፋይል (CSV)</string>
@@ -127,7 +126,6 @@
     <string name="device_address">IP አድራሻ</string>
     <string name="csv_export_description">Options for formatting CSV export files</string>
     <string name="conversions">ዳታ መቀየሪያ</string>
-    <string name="night_mode">የማታ አማራጭ</string>
     <string name="comma">COMMA</string>
     <string name="csv_field_delimiter_description">የ CSV ዳታ ፊልድ የፊደላት መለያ ካራክተር</string>
     <string name="share">አጋራ</string>

--- a/androbd/src/main/res/values-ar/strings.xml
+++ b/androbd/src/main/res/values-ar/strings.xml
@@ -81,8 +81,6 @@
     <string name="unabletoconnect">غير قادر على وصل الجهاز</string>
     <string name="connectionlost">انقطع اتصال الجهاز</string>
     <string name="day_night_mode">وضع الشاشة ليلي \\ نهاري</string>
-    <string name="night_mode_description">تعيين الشاشة إلى خلفية داكنة</string>
-    <string name="night_mode">الوضع اليلي</string>
     <string name="disconnect">إقطع الإتصال</string>
     <string name="use_last_settings">استخدام الإعدادات الأخيرة</string>
     <string name="common_settings_description">إعدادات عامة لمراقبة التطبيق</string>

--- a/androbd/src/main/res/values-be/strings.xml
+++ b/androbd/src/main/res/values-be/strings.xml
@@ -95,8 +95,6 @@
     <string name="connectionlost">Злучэнне з прыладай страчанае</string>
     <string name="elm_timeout_descr">Мінімальнае чаканне адказу ад ELM, мс</string>
     <string name="day_night_mode">Дзённы/Начны рэжым прагляду</string>
-    <string name="night_mode_description">Устанавіць цёмны фон экрана</string>
-    <string name="night_mode">Начны рэжым</string>
     <string name="disable_elm_cmds">Адключаныя ELM-каманды</string>
     <string name="disable_elm_cmds_descr">уключыць/адключыць ELM-каманды</string>
     <string name="elm_adaptive_timing">Адаптыўны таймінг ELM</string>

--- a/androbd/src/main/res/values-ca/strings.xml
+++ b/androbd/src/main/res/values-ca/strings.xml
@@ -105,8 +105,6 @@
     <string name="select_extension">Triar el fitxer d\'extensió .csv…</string>
     <string name="obd_options">Opcions d\'OBD</string>
     <string name="day_night_mode">Mode de visualització dia/nit</string>
-    <string name="night_mode_description">Establir fons de pantalla fosc</string>
-    <string name="night_mode">Mode nit</string>
     <string name="disable_elm_cmds">Ordres ELM desactivades</string>
     <string name="disable_elm_cmds_descr">activar/desactivar ordres ELM</string>
     <string name="elm_adaptive_timing">Temporització adaptativa ELM</string>

--- a/androbd/src/main/res/values-ckb/strings.xml
+++ b/androbd/src/main/res/values-ckb/strings.xml
@@ -56,8 +56,6 @@
     <string name="connectionlost"/>
     <string name="elm_timeout_descr"/>
     <string name="day_night_mode">شێوازی بینینی ڕۆژ/شەو</string>
-    <string name="night_mode_description"/>
-    <string name="night_mode">شێوازی شەو</string>
     <string name="disable_elm_cmds"/>
     <string name="disable_elm_cmds_descr"/>
     <string name="elm_adaptive_timing"/>

--- a/androbd/src/main/res/values-cs/strings.xml
+++ b/androbd/src/main/res/values-cs/strings.xml
@@ -135,8 +135,6 @@
     <string name="elm_adaptive_timing">Adaptivní časování ELM</string>
     <string name="disable_elm_cmds_descr">povolit/zakázat příkazy ELM</string>
     <string name="disable_elm_cmds">Zakázané příkazy ELM</string>
-    <string name="night_mode">Noční režim</string>
-    <string name="night_mode_description">Nastavit tmavé pozadí obrazovky</string>
     <string name="day_night_mode">Denní/noční režim zobrazení</string>
     <string name="elm_timeout_descr">Minimální časový limit čekání v [ms] na odpovědi ELM</string>
     <string name="min_elm_timeout">Min. časový limit ELM [ms]</string>

--- a/androbd/src/main/res/values-da/strings.xml
+++ b/androbd/src/main/res/values-da/strings.xml
@@ -57,8 +57,6 @@
     <string name="unabletoconnect">Kunne ikke forbinde til enheden</string>
     <string name="connectionlost">Mistede forbindelsen til enheden</string>
     <string name="day_night_mode">Dag/nat visningstilstand</string>
-    <string name="night_mode_description">Gør skærmens baggrunden mørk</string>
-    <string name="night_mode">Nat tilstand</string>
     <string name="disable_elm_cmds">Deaktiveret ELM kommandoer</string>
     <string name="disable_elm_cmds_descr">Aktiverer/deaktiverer ELM kommandoer</string>
     <string name="elm_reset_on_nrc">Nulstil ved NRC</string>

--- a/androbd/src/main/res/values-de/strings.xml
+++ b/androbd/src/main/res/values-de/strings.xml
@@ -97,8 +97,6 @@
     <string name="unabletoconnect">Verbindung nicht möglich</string>
     <string name="elm_timeout_descr">Minimaler Timeout [ms] für ELM Antworten</string>
     <string name="day_night_mode">Tag/Nacht Ansicht</string>
-    <string name="night_mode">Nachtmodus</string>
-    <string name="night_mode_description">Ansicht mit dunklem Hintergrund</string>
     <string name="disable_elm_cmds">Deaktivierte ELM-Befehle</string>
     <string name="disable_elm_cmds_descr">ELM Befehle aktivieren / deaktivieren</string>
     <string name="elm_adaptive_timing">Adaptives ELM timing</string>

--- a/androbd/src/main/res/values-es/strings.xml
+++ b/androbd/src/main/res/values-es/strings.xml
@@ -88,7 +88,6 @@
     <string name="select_medium">Tipo de adaptador…</string>
     <string name="devices_found">%d dispositivo(s) USB encontrado(s)</string>
     <string name="unabletoconnect">Imposible conectar con el dispositivo</string>
-    <string name="night_mode">Modo nocturno</string>
     <string name="disconnect">Desconectar</string>
     <string name="use_last_settings">Utilizar última configuración</string>
     <string name="secure_connect">Conexión segura</string>
@@ -111,7 +110,6 @@
     <string name="min_elm_timeout">Min. Tiempo de espera del ELM [ms]</string>
     <string name="connectionlost">Se perdió la conexión con el dispositivo</string>
     <string name="elm_timeout_descr">Tiempo de espera mínimo en [ms] para las respuestas ELM</string>
-    <string name="night_mode_description">Establecer fondo de pantalla oscuro</string>
     <string name="disable_elm_cmds">Órdenes ELM desactivadas</string>
     <string name="disable_elm_cmds_descr">activar/desactivar órdenes ELM</string>
     <string name="elm_adaptive_timing">Tiempo adaptativo del ELM</string>

--- a/androbd/src/main/res/values-fi/strings.xml
+++ b/androbd/src/main/res/values-fi/strings.xml
@@ -82,8 +82,6 @@
     <string name="connectionlost">Yhteys laitteeseen katkesi</string>
     <string name="elm_timeout_descr">ELM:n vastausten odottamisen vähimmäisaikakatkaisu, yksikkönä [ms]</string>
     <string name="day_night_mode">Päivä-/yönäkymä</string>
-    <string name="night_mode_description">Aseta näytön tausta tummaksi</string>
-    <string name="night_mode">Yötila</string>
     <string name="disable_elm_cmds">Käytöstä poistetut ELM-komennot</string>
     <string name="disable_elm_cmds_descr">estä/salli ELM-komentoja</string>
     <string name="elm_adaptive_timing">ELM:n mukautuva ajoitus</string>

--- a/androbd/src/main/res/values-fr/strings.xml
+++ b/androbd/src/main/res/values-fr/strings.xml
@@ -91,8 +91,6 @@
     <string name="connectionlost">La connexion vers l\'appareil est perdue</string>
     <string name="elm_timeout_descr">Délai d\'attente min. (ms) pour attendre réponse d\'ELM</string>
     <string name="day_night_mode">Mode d’affichage jour/nuit</string>
-    <string name="night_mode_description">Régler affichage sur fond sombre</string>
-    <string name="night_mode">Mode nuit</string>
     <string name="disable_elm_cmds">Commandes ELM inactivées</string>
     <string name="disable_elm_cmds_descr">activer/désactiver commandes ELM</string>
     <string name="elm_adaptive_timing">Synchro adaptative ELM</string>

--- a/androbd/src/main/res/values-gl/strings.xml
+++ b/androbd/src/main/res/values-gl/strings.xml
@@ -60,8 +60,6 @@
     <string name="elm_reset_on_nrc">Restablecer en NRC</string>
     <string name="disable_elm_cmds_descr">habilitar / desactivar os comandos ELM</string>
     <string name="disable_elm_cmds">Comandos ELM desactivados</string>
-    <string name="night_mode">Modo nocturno</string>
-    <string name="night_mode_description">Establecer a pantalla a fondo escuro</string>
     <string name="day_night_mode">Modo de visualización de día / noite</string>
     <string name="elm_timeout_descr">Tempo mínimo de espera en [ms] para agardar as respostas de ELM</string>
     <string name="connectionlost">Perdeuse a conexión do dispositivo</string>

--- a/androbd/src/main/res/values-hu/strings.xml
+++ b/androbd/src/main/res/values-hu/strings.xml
@@ -93,8 +93,6 @@
     <string name="connectionlost">Megszakadt a kapcsolat</string>
     <string name="elm_timeout_descr">Legkevesebb időtúllépés [ms] az ELM válaszaira</string>
     <string name="day_night_mode">Nappali/éjszakai mód</string>
-    <string name="night_mode_description">Sötét háttér beállítása a kijelzőn</string>
-    <string name="night_mode">Éjszakai mód</string>
     <string name="disable_elm_cmds">Letiltott ELM-parancsok</string>
     <string name="disable_elm_cmds_descr">ELM-parancsok engedélyezése/letiltása</string>
     <string name="elm_adaptive_timing">ELM adaptív időzítése</string>

--- a/androbd/src/main/res/values-in/strings.xml
+++ b/androbd/src/main/res/values-in/strings.xml
@@ -71,8 +71,6 @@
     <string name="unabletoconnect">Tidak dapat menghubungkan perangkat</string>
     <string name="connectionlost">Sambungan perangkat terputus</string>
     <string name="day_night_mode">Mode tampilan Siang/Malam</string>
-    <string name="night_mode_description">Atur tampilan ke latar belakang gelap</string>
-    <string name="night_mode">Mode malam</string>
     <string name="disable_elm_cmds">Perintah ELM dinonaktifkan</string>
     <string name="disable_elm_cmds_descr">aktifkan/nonaktifkan perintah ELM</string>
     <string name="elm_adaptive_timing_descr">Izinkan penanganan pengaturan waktu adaptif pada driver ELM\?</string>

--- a/androbd/src/main/res/values-it/strings.xml
+++ b/androbd/src/main/res/values-it/strings.xml
@@ -95,8 +95,6 @@
     <string name="connectionlost">Persa connessione con il dispositivo</string>
     <string name="elm_timeout_descr">Timeout minimo in [ms] per attenedere una risposta dall\'ELM</string>
     <string name="day_night_mode">Modalità giorno/notte</string>
-    <string name="night_mode_description">Imposta uno sfondo scuro</string>
-    <string name="night_mode">Modalità notturna</string>
     <string name="disable_elm_cmds">Disabilita comandi ELM</string>
     <string name="disable_elm_cmds_descr">attiva/disattiva comandi ELM</string>
     <string name="elm_adaptive_timing">Tempi adattativi per ELM</string>

--- a/androbd/src/main/res/values-iw/strings.xml
+++ b/androbd/src/main/res/values-iw/strings.xml
@@ -93,8 +93,6 @@
     <string name="connectionlost">החיבור להתקן אבד</string>
     <string name="elm_timeout_descr">משך הזמן הקצר ביותר ב[מילישניות] להמתנה לתגובות מה־ELM</string>
     <string name="day_night_mode">מצב תצוגה יום/לילה</string>
-    <string name="night_mode_description">הגדרת התצוגה לרקע כהה</string>
-    <string name="night_mode">מצב לילה</string>
     <string name="disable_elm_cmds">פקודות ELM מושבתות</string>
     <string name="disable_elm_cmds_descr">הפעלה/השבתה של פקודות ELM</string>
     <string name="elm_adaptive_timing">תזמון מסתגל של ELM</string>

--- a/androbd/src/main/res/values-ja/strings.xml
+++ b/androbd/src/main/res/values-ja/strings.xml
@@ -75,8 +75,6 @@
     <string name="connectionlost">デバイスの接続が失われました</string>
     <string name="elm_timeout_descr">ELM 応答を待つ最小タイムアウト [ミリ秒]</string>
     <string name="day_night_mode">昼間/夜間表示モード</string>
-    <string name="night_mode_description">表示を暗い背景に設定します</string>
-    <string name="night_mode">夜間モード</string>
     <string name="disable_elm_cmds">ELM コマンドを無効にしました</string>
     <string name="disable_elm_cmds_descr">ELM コマンドを有効/無効にします</string>
     <string name="elm_adaptive_timing">ELM 適応タイミング</string>

--- a/androbd/src/main/res/values-ko/strings.xml
+++ b/androbd/src/main/res/values-ko/strings.xml
@@ -94,8 +94,6 @@
     <string name="connectionlost">기기 연결이 끊어졌습니다</string>
     <string name="elm_timeout_descr">ELM 응답을 기다리는 최소 시간 제한 [ms]</string>
     <string name="day_night_mode">주/야간 모드</string>
-    <string name="night_mode_description">디스플레이를 어두운 배경으로 설정</string>
-    <string name="night_mode">야간모드</string>
     <string name="disable_elm_cmds">사용하지 않는 ELM 명령</string>
     <string name="disable_elm_cmds_descr">ELM 명령을 활성화 / 비활성화합니다</string>
     <string name="elm_adaptive_timing">ELM 적응 타이밍</string>

--- a/androbd/src/main/res/values-lt/strings.xml
+++ b/androbd/src/main/res/values-lt/strings.xml
@@ -89,8 +89,6 @@
     <string name="select_ecu_addr">Pasirinkite ECU adresą …</string>
     <string name="disable_elm_cmds_descr">įjunkite/išjunkite ELM komandas</string>
     <string name="disable_elm_cmds">Išjungtos ELM komandos</string>
-    <string name="night_mode">Nakties rėžimas</string>
-    <string name="night_mode_description">Nustatyti tamsų ekrano foną</string>
     <string name="day_night_mode">Dienos/nakties peržiūros režimas</string>
     <string name="connectionlost">Prarastas ryšys su įrenginiu</string>
     <string name="unabletoconnect">Nepavyksta prijungti įrenginio</string>

--- a/androbd/src/main/res/values-nb-rNO/strings.xml
+++ b/androbd/src/main/res/values-nb-rNO/strings.xml
@@ -56,8 +56,6 @@
     <string name="unabletoconnect">Kunne ikke koble til enhet</string>
     <string name="connectionlost">Enhetstilkobling gikk tapt</string>
     <string name="day_night_mode">Dag/natt-visningsmodus</string>
-    <string name="night_mode_description">Bruk mørk bakgrunn</string>
-    <string name="night_mode">Nattmodus</string>
     <string name="disable_elm_cmds">Avskrudde ELM-kommandoer</string>
     <string name="disable_elm_cmds_descr">skru på/av ELM-kommandoer</string>
     <string name="select_ecu_addr">Velg ECU-adresse…</string>

--- a/androbd/src/main/res/values-nl/strings.xml
+++ b/androbd/src/main/res/values-nl/strings.xml
@@ -85,7 +85,6 @@
     <string name="unabletoconnect">Kan geen verbinding maken met het apparaat</string>
     <string name="INITIALIZED">Geïnitialiseerd</string>
     <string name="select_ecu_addr">Selecteer ECU adres …</string>
-    <string name="night_mode">Nacht modus</string>
     <string name="ECU_DETECTED">ECU gedetecteerd</string>
     <string name="CONNECTED">Verbonden</string>
     <string name="secure_connect">Beveiligde verbinding</string>
@@ -99,7 +98,6 @@
     <string name="common_settings_description">Algemene instellingen voor app bediening</string>
     <string name="reset_preselections">Laatste voorselecties resetten</string>
     <string name="elm_adaptive_timing">ELM adaptieve timing</string>
-    <string name="night_mode_description">Donkere achtergrond instellen</string>
     <string name="day_night_mode">Dag/Nacht modus</string>
     <string name="elm_options">ELM opties</string>
     <string name="elm_timeout_descr">Minimale timeout in [ms] om te wachten op ELM reacties</string>

--- a/androbd/src/main/res/values-pl/strings.xml
+++ b/androbd/src/main/res/values-pl/strings.xml
@@ -92,8 +92,6 @@
     <string name="connectionlost">Połączenie urządzenia zostało utracone</string>
     <string name="elm_timeout_descr">Minimalny czas oczekiwania [ms] na odpowiedź ELM</string>
     <string name="day_night_mode">Tryb widoku Dzień/Noc</string>
-    <string name="night_mode_description">Ustaw wyświetlacz na ciemnym tle</string>
-    <string name="night_mode">Tryb nocny</string>
     <string name="disable_elm_cmds">Wyłączone komendy ELM</string>
     <string name="disable_elm_cmds_descr">włącz/wyłącz komendy ELM</string>
     <string name="elm_adaptive_timing">czas adaptacji ELM</string>

--- a/androbd/src/main/res/values-pt-rBR/strings.xml
+++ b/androbd/src/main/res/values-pt-rBR/strings.xml
@@ -95,8 +95,6 @@
     <string name="connectionlost">A conexão do dispositivo foi perdida</string>
     <string name="elm_timeout_descr">Tempo limite mínimo em [ms] para aguardar respostas de ELM</string>
     <string name="day_night_mode">Modo de visualização dia/noite</string>
-    <string name="night_mode_description">Definir tela para fundo escuro</string>
-    <string name="night_mode">Modo noturno</string>
     <string name="disable_elm_cmds">Comandos ELM desativados</string>
     <string name="disable_elm_cmds_descr">ativar/desativar comandos ELM</string>
     <string name="elm_adaptive_timing">Tempo adaptativo ELM</string>

--- a/androbd/src/main/res/values-pt-rPT/strings.xml
+++ b/androbd/src/main/res/values-pt-rPT/strings.xml
@@ -58,8 +58,6 @@
     <string name="select_medium">Tipo de adaptador…</string>
     <string name="devices_found">%d aparelho(s) USB encontrado(s)</string>
     <string name="day_night_mode">Modo de visualização dia/noite</string>
-    <string name="night_mode_description">Definir ecrã para fundo escuro</string>
-    <string name="night_mode">Modo noturno</string>
     <string name="disable_elm_cmds">Comandos ELM desativados</string>
     <string name="disable_elm_cmds_descr">ativar/desativar comandos ELM</string>
     <string name="disconnect">Desligar</string>

--- a/androbd/src/main/res/values-pt/strings.xml
+++ b/androbd/src/main/res/values-pt/strings.xml
@@ -68,8 +68,6 @@
     <string name="elm_adaptive_timing">Tempo adaptativo ELM</string>
     <string name="disable_elm_cmds_descr">ativar/desativar comandos ELM</string>
     <string name="disable_elm_cmds">Comandos ELM desativados</string>
-    <string name="night_mode">Modo noturno</string>
-    <string name="night_mode_description">Definir ecrã para fundo escuro</string>
     <string name="day_night_mode">Modo de visualização dia/noite</string>
     <string name="elm_timeout_descr">Tempo de limite mínimo em [ms] para aguardar por respostas de ELM</string>
     <string name="connectionlost">A ligação do aparelho foi perdida</string>

--- a/androbd/src/main/res/values-ru/strings.xml
+++ b/androbd/src/main/res/values-ru/strings.xml
@@ -86,8 +86,6 @@
     <string name="connectionlost">Подключение к устройству потеряно</string>
     <string name="elm_timeout_descr">Минимальное ожидание ответа ELM [мс]</string>
     <string name="day_night_mode">Дневной/Ночной режим просмотра</string>
-    <string name="night_mode_description">Установить темный фон</string>
-    <string name="night_mode">Ночной режим</string>
     <string name="disable_elm_cmds">Отключенные команды ELM</string>
     <string name="disable_elm_cmds_descr">Вкл/откл команды ELM</string>
     <string name="elm_adaptive_timing">Адаптивный тайминг ELM</string>

--- a/androbd/src/main/res/values-sl/strings.xml
+++ b/androbd/src/main/res/values-sl/strings.xml
@@ -55,7 +55,6 @@
     <string name="select_medium">Tip adapterja …</string>
     <string name="devices_found">%d odkritih USB naprav</string>
     <string name="day_night_mode">Dnevni/Nočni način</string>
-    <string name="night_mode">Nočni način</string>
     <string name="disable_elm_cmds">Onemogočeni ELM ukazi</string>
     <string name="disable_elm_cmds_descr">omogoči/onemogoči ELM ukaze</string>
     <string name="select_ecu_addr">Izberi ECU naslov …</string>
@@ -94,7 +93,6 @@
     <string name="filter">Filter izbran</string>
     <string name="unabletoconnect">Povezava z napravo je neuspešna</string>
     <string name="connectionlost">Povezava z napravo je bila izgubljena</string>
-    <string name="night_mode_description">Nastavi zaslon na temno ozadje</string>
     <string name="INITIALIZING">Inicializacija…</string>
     <string name="INITIALIZED">Inicializirano</string>
     <string name="device_port">ELM IP vhod</string>

--- a/androbd/src/main/res/values-sr/strings.xml
+++ b/androbd/src/main/res/values-sr/strings.xml
@@ -92,8 +92,6 @@
     <string name="connectionlost">Veza sa uređajem je prekinuta</string>
     <string name="elm_timeout_descr">Minmalni istek vremena u [ms] za odgovor od ELM uređaja</string>
     <string name="day_night_mode">Dan/Noć mod prikaza</string>
-    <string name="night_mode_description">Postavi tamnu pozadinu na ekranu</string>
-    <string name="night_mode">Noćni rezim</string>
     <string name="disable_elm_cmds">Onemogućene ELM komande</string>
     <string name="disable_elm_cmds_descr">omogući/onemogući ELM komande</string>
     <string name="elm_adaptive_timing">ELM adaptivni tajming</string>

--- a/androbd/src/main/res/values-sv/strings.xml
+++ b/androbd/src/main/res/values-sv/strings.xml
@@ -95,8 +95,6 @@
     <string name="connectionlost">Enhetsanslutning förlorades</string>
     <string name="elm_timeout_descr">Minsta tidsgräns i [ms] att vänta på ELM-svar</string>
     <string name="day_night_mode">Dag-/Nattläge</string>
-    <string name="night_mode_description">Stället in visning av mörk bakgrund</string>
-    <string name="night_mode">Nattläge</string>
     <string name="disable_elm_cmds">Inaktiverade ELM-kommandon</string>
     <string name="disable_elm_cmds_descr">aktivera/inaktivera ELM-kommandon</string>
     <string name="elm_adaptive_timing">Adaptiv ELM-tidtagning</string>

--- a/androbd/src/main/res/values-tr/strings.xml
+++ b/androbd/src/main/res/values-tr/strings.xml
@@ -95,8 +95,6 @@
     <string name="connectionlost">Cihazla bağlantı koptu</string>
     <string name="elm_timeout_descr">Azami ELM bekleme zaman aşımı [ms]</string>
     <string name="day_night_mode">Gündüz/Gece modu</string>
-    <string name="night_mode_description">Arka planı koyu yap</string>
-    <string name="night_mode">Gece modu</string>
     <string name="disable_elm_cmds">ELM komutlarını kapat</string>
     <string name="disable_elm_cmds_descr">"ELM komutlarını etkinleştir/kapat "</string>
     <string name="elm_adaptive_timing">ELM zamanlaması</string>

--- a/androbd/src/main/res/values-uk/strings.xml
+++ b/androbd/src/main/res/values-uk/strings.xml
@@ -76,8 +76,6 @@
     <string name="connectionlost">Розірвано з\'єднання з пристроєм</string>
     <string name="elm_timeout_descr">Мінімальний час очікування в [мс] відповідей ELM</string>
     <string name="day_night_mode">Денний/Нічний режим перегляду</string>
-    <string name="night_mode_description">Встановити темне тло екрана</string>
-    <string name="night_mode">Нічний режим</string>
     <string name="disable_elm_cmds">Вимкнені команди ELM</string>
     <string name="disable_elm_cmds_descr">увімкнути/ввімкнути команди ELM</string>
     <string name="elm_adaptive_timing">Адаптивний таймінг ELM</string>

--- a/androbd/src/main/res/values-zh-rCN/strings.xml
+++ b/androbd/src/main/res/values-zh-rCN/strings.xml
@@ -94,8 +94,6 @@
     <string name="connectionlost">与设备连接已断开</string>
     <string name="elm_timeout_descr">等待ELM响应的最小超时时间 [ms]</string>
     <string name="day_night_mode">白天/夜间 视图模式</string>
-    <string name="night_mode_description">设置背景为黑色</string>
-    <string name="night_mode">夜间模式</string>
     <string name="disable_elm_cmds">禁用ELM指令</string>
     <string name="disable_elm_cmds_descr">启用/禁用 ELM指令</string>
     <string name="elm_adaptive_timing">ELM 自适应时间</string>

--- a/androbd/src/main/res/values-zh-rTW/strings.xml
+++ b/androbd/src/main/res/values-zh-rTW/strings.xml
@@ -95,8 +95,6 @@
     <string name="connectionlost">設備無連缐</string>
     <string name="elm_timeout_descr">[ms] 中等待 ELM 回應的最小超時</string>
     <string name="day_night_mode">日/夜視圖模式</string>
-    <string name="night_mode_description">將顯示設定為深色背景</string>
-    <string name="night_mode">夜間模式</string>
     <string name="disable_elm_cmds">禁用ELM指令</string>
     <string name="disable_elm_cmds_descr">啟用/禁用 ELM 命令</string>
     <string name="elm_adaptive_timing">ELM 自我調整定時</string>

--- a/androbd/src/main/res/values/strings.xml
+++ b/androbd/src/main/res/values/strings.xml
@@ -175,8 +175,18 @@ period of time while the ECU recalibrates itself.
     <string name="connectionlost">Device connection was lost</string>
     <string name="elm_timeout_descr">Minimum timeout in [ms] to wait for ELM responses</string>
     <string name="day_night_mode">Day/Night view mode</string>
-    <string name="night_mode_description">Set display to dark background</string>
-    <string name="night_mode">Night mode</string>
+    <string name="theme_mode">Theme</string>
+    <string name="theme_mode_description">Follow the system theme, or force light or dark</string>
+    <string-array name="theme_mode_entries">
+        <item>Follow system</item>
+        <item>Light</item>
+        <item>Dark</item>
+    </string-array>
+    <string-array name="theme_mode_values">
+        <item>system</item>
+        <item>light</item>
+        <item>dark</item>
+    </string-array>
     <string name="disable_elm_cmds">Disabled ELM commands</string>
     <string name="disable_elm_cmds_descr">enable/disable ELM commands</string>
     <string name="elm_adaptive_timing">ELM adaptive timing</string>

--- a/androbd/src/main/res/values/styles.xml
+++ b/androbd/src/main/res/values/styles.xml
@@ -1,10 +1,6 @@
 <resources>
     <!-- Application theme. -->
-    <style name="AppTheme" parent="Theme.Material3.Light" >
-        <item name="android:activatedBackgroundIndicator">@drawable/activated_background</item>
-        <item name="android:fitsSystemWindows">true</item>
-    </style>
-    <style name="AppTheme.Dark" parent="Theme.Material3.Dark" >
+    <style name="AppTheme" parent="Theme.Material3.DayNight" >
         <item name="android:activatedBackgroundIndicator">@drawable/activated_background</item>
         <item name="android:fitsSystemWindows">true</item>
     </style>

--- a/androbd/src/main/res/xml/settings.xml
+++ b/androbd/src/main/res/xml/settings.xml
@@ -72,11 +72,14 @@
 
         </PreferenceCategory>
 
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:key="night_mode"
-            android:summary="@string/night_mode_description"
-            android:title="@string/night_mode"
+        <ListPreference
+            android:defaultValue="system"
+            android:dialogTitle="@string/theme_mode"
+            android:entries="@array/theme_mode_entries"
+            android:entryValues="@array/theme_mode_values"
+            android:key="theme_mode"
+            android:summary="@string/theme_mode_description"
+            android:title="@string/theme_mode"
             />
 
         <ListPreference

--- a/androbd/src/test/java/com/fr3ts0n/ecu/gui/androbd/MainActivityThemeModeTest.java
+++ b/androbd/src/test/java/com/fr3ts0n/ecu/gui/androbd/MainActivityThemeModeTest.java
@@ -1,0 +1,127 @@
+package com.fr3ts0n.ecu.gui.androbd;
+
+import android.content.SharedPreferences;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import androidx.appcompat.app.AppCompatDelegate;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Local JVM unit tests for {@link MainActivity#getThemeModePref} and
+ * {@link MainActivity#themeModeToNightMode}, the tri-state theme preference
+ * helpers introduced for issue #128. Both are pure static methods, exercised
+ * here against a minimal in-memory {@link SharedPreferences} fake rather than
+ * a real Android runtime.
+ */
+public class MainActivityThemeModeTest
+{
+    /** Minimal in-memory SharedPreferences, just enough for these tests. */
+    private static class FakePrefs implements SharedPreferences
+    {
+        final Map<String, Object> values = new HashMap<>();
+
+        @Override public Map<String, ?> getAll() { return values; }
+        @Override public String getString(String key, String defValue)
+        {
+            return values.containsKey(key) ? (String) values.get(key) : defValue;
+        }
+        @Override public Set<String> getStringSet(String key, Set<String> defValues) { throw new UnsupportedOperationException(); }
+        @Override public int getInt(String key, int defValue) { throw new UnsupportedOperationException(); }
+        @Override public long getLong(String key, long defValue) { throw new UnsupportedOperationException(); }
+        @Override public float getFloat(String key, float defValue) { throw new UnsupportedOperationException(); }
+        @Override public boolean getBoolean(String key, boolean defValue)
+        {
+            return values.containsKey(key) ? (Boolean) values.get(key) : defValue;
+        }
+        @Override public boolean contains(String key) { return values.containsKey(key); }
+        @Override public Editor edit() { return new FakeEditor(); }
+        @Override public void registerOnSharedPreferenceChangeListener(OnSharedPreferenceChangeListener listener) { }
+        @Override public void unregisterOnSharedPreferenceChangeListener(OnSharedPreferenceChangeListener listener) { }
+
+        private class FakeEditor implements Editor
+        {
+            private final Map<String, Object> pending = new HashMap<>(values);
+            private final Set<String> removed = new HashSet<>();
+
+            @Override public Editor putString(String key, String value) { pending.put(key, value); return this; }
+            @Override public Editor putStringSet(String key, Set<String> values) { throw new UnsupportedOperationException(); }
+            @Override public Editor putInt(String key, int value) { throw new UnsupportedOperationException(); }
+            @Override public Editor putLong(String key, long value) { throw new UnsupportedOperationException(); }
+            @Override public Editor putFloat(String key, float value) { throw new UnsupportedOperationException(); }
+            @Override public Editor putBoolean(String key, boolean value) { pending.put(key, value); return this; }
+            @Override public Editor remove(String key) { removed.add(key); pending.remove(key); return this; }
+            @Override public Editor clear() { pending.clear(); return this; }
+            @Override public boolean commit() { apply(); return true; }
+            @Override public void apply()
+            {
+                for (String key : removed) { values.remove(key); }
+                values.putAll(pending);
+            }
+        }
+    }
+
+    @Test
+    public void getThemeModePref_defaultsToSystem_whenNothingStored()
+    {
+        assertEquals("system", MainActivity.getThemeModePref(new FakePrefs()));
+    }
+
+    @Test
+    public void getThemeModePref_readsExistingThemeModeValue()
+    {
+        FakePrefs prefs = new FakePrefs();
+        prefs.values.put("theme_mode", "dark");
+        assertEquals("dark", MainActivity.getThemeModePref(prefs));
+    }
+
+    @Test
+    public void getThemeModePref_migratesLegacyTrueToDark()
+    {
+        FakePrefs prefs = new FakePrefs();
+        prefs.values.put("night_mode", true);
+        assertEquals("dark", MainActivity.getThemeModePref(prefs));
+        assertEquals("dark", prefs.values.get("theme_mode"));
+        assertFalse("legacy key should be removed after migration", prefs.contains("night_mode"));
+    }
+
+    @Test
+    public void getThemeModePref_migratesLegacyFalseToLight()
+    {
+        FakePrefs prefs = new FakePrefs();
+        prefs.values.put("night_mode", false);
+        assertEquals("light", MainActivity.getThemeModePref(prefs));
+        assertEquals("light", prefs.values.get("theme_mode"));
+        assertFalse("legacy key should be removed after migration", prefs.contains("night_mode"));
+    }
+
+    @Test
+    public void getThemeModePref_newKeyTakesPriorityOverLegacyKey()
+    {
+        FakePrefs prefs = new FakePrefs();
+        prefs.values.put("night_mode", true);
+        prefs.values.put("theme_mode", "light");
+        assertEquals("light", MainActivity.getThemeModePref(prefs));
+    }
+
+    @Test
+    public void themeModeToNightMode_mapsAllThreeStates()
+    {
+        assertEquals(AppCompatDelegate.MODE_NIGHT_YES, MainActivity.themeModeToNightMode("dark"));
+        assertEquals(AppCompatDelegate.MODE_NIGHT_NO, MainActivity.themeModeToNightMode("light"));
+        assertEquals(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM, MainActivity.themeModeToNightMode("system"));
+    }
+
+    @Test
+    public void themeModeToNightMode_unknownValueFallsBackToSystem()
+    {
+        assertEquals(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM, MainActivity.themeModeToNightMode("anything-else"));
+    }
+}


### PR DESCRIPTION
Closes #128.

## What this does

Migrates day/night theme switching to `AppCompatDelegate`'s built-in day/night modes, per the "1st option" discussed on the issue:

- Merges `AppTheme`/`AppTheme.Dark` into a single `AppTheme` on `Theme.Material3.DayNight`, applied at the `<application>` level.
- Removes the five manual `setTheme(MainActivity.nightMode ? R.style.AppTheme_Dark : R.style.AppTheme)` calls that were scattered across `DashBoardActivity`, `BtDeviceListActivity`, `ChartActivity`, `UsbDeviceListActivity`, and `SettingsActivity`.
- Replaces the boolean `night_mode` preference with a tri-state `theme_mode` preference (System / Light / Dark), migrating an existing user's boolean choice to the new key on first read (`true` → Dark, `false` → Light), so nobody's current setting is silently reset.
- The quick "Day/Night view mode" menu toggle now forces the opposite of whatever's currently displayed, instead of just flipping a boolean.

## Known limitation

`MainActivity` doesn't extend `AppCompatActivity` — it extends the legacy `ListActivity` via `PluginManager`. I tested this on-device (Pixel 10, Android 16): "Follow system" works correctly everywhere, including `MainActivity`, since that just tracks the real system setting with no override involved. But an explicit **Light** or **Dark** override doesn't reach `MainActivity` specifically — confirmed with a genuine cold start, not just a backgrounded `recreate()` — because `AppCompatDelegate`'s override only applies to components it tracks (`AppCompatActivity` subclasses), which `MainActivity` isn't. Every other screen (Settings, Chart, Dashboard, BT/USB device lists) honours the override correctly.

Fixing this fully would mean migrating `MainActivity` off `ListActivity` onto `AppCompatActivity` — a separate, much larger change to the app's entry point that I didn't want to bundle into this PR unannounced. Happy to do that as a follow-up if you'd like it, or leave it as a known gap if "Follow system" covering the main screen is good enough.

## Testing

- `./gradlew :androbd:testDebugUnitTest` — all pass, including new unit tests for the preference-migration logic (`MainActivityThemeModeTest`).
- `./gradlew :androbd:lintDebug` — clean (fixed an `ExtraTranslation` lint error along the way: removed the now-orphaned `night_mode`/`night_mode_description` string translations from all ~30 locale files, since the default-locale strings they translated no longer exist).
- `./gradlew :androbd:assembleDebug` — builds clean.
- Manually tested on a Pixel 10 (Android 16): cold start under System/Light/Dark, live preference changes, and the quick-toggle menu item, across MainActivity and Settings.

## AI disclosure

Drafted with Claude, based on my own review of the theming code and the option you picked on #128; tested and verified by me on-device before opening this.
