### PR TITLE
Workaround poor adapter #348: Fix ISO9141 header handling

### DIFF
--- a/androbd/build.gradle
+++ b/androbd/build.gradle
@@ -12,8 +12,8 @@ android {
     defaultConfig {
         minSdkVersion 17
         targetSdkVersion 36
-        versionCode 20710
-        versionName 'V2.7.10'
+        versionCode 20711
+        versionName 'V2.7.11'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/library/src/main/java/com/fr3ts0n/ecu/prot/obd/ElmProt.java
+++ b/library/src/main/java/com/fr3ts0n/ecu/prot/obd/ElmProt.java
@@ -22,6 +22,7 @@ import com.fr3ts0n.prot.TelegramListener;
 import com.fr3ts0n.prot.TelegramWriter;
 
 import java.beans.PropertyChangeEvent;
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -643,7 +644,52 @@ public class ElmProt
 	 * multiline response is pending, for responses w/o a length info
 	 */
 	private boolean responsePending = false;
-	
+
+	/**
+	 * Get buffer as byte array from HEX string
+	 * @param buffer hex string char buffer
+	 * @return byte[] of buffer content
+	 */
+    private byte[] fromHex(char[] buffer)
+	{
+		return new BigInteger(String.copyValueOf(buffer),16).toByteArray();
+	}
+
+	/**
+	 * Check if buffer contains a valid ISO telegram
+	 * @param buffer Telegram buffer
+	 * @return true if buffer contains valid ISO telegram, false otherwise
+	 */
+	private boolean isValidIsoTelegram(char[] buffer)
+	{
+		boolean result = false;
+		// ISO Header=3bytes, footer=1byte > min 8 hex digits
+		if(buffer.length > 8)
+		{
+			try {
+				int i;
+				int crc=0;
+				byte[] binBuff = fromHex(buffer);
+				for (i=0; i<binBuff.length-1; i++)
+				{
+					crc += binBuff[i];
+				}
+				// check last byte matching accumulated CRC
+				result = (crc == binBuff[i]);
+			} catch (Exception e) {
+				// Ignore exception - result=false
+			}
+		}
+		return result;
+	}
+
+	private String extractIsoContent(char[] buffer)
+	{
+		/* Extract payload content out of ISO telegram
+		 * ISO Tgm.: <TYPE><SENDER><DESTINATION><PayLoad...><CRC> */
+		return String.copyValueOf(buffer,6,buffer.length-8);
+	}
+
 	/**
 	 * handle incoming protocol telegram
 	 *
@@ -655,9 +701,12 @@ public class ElmProt
 	{
 		int result = 0;
 		String bufferStr = new String(buffer);
-		
+		if( isValidIsoTelegram(buffer) )
+			// extract ISO content
+			bufferStr = extractIsoContent(buffer);
+
 		log.fine(this.toString() + " RX:'" + bufferStr + "'");
-		
+
 		// empty result
 		if (buffer.length == 0)
 		{
@@ -896,9 +945,11 @@ public class ElmProt
 							log.fine(String.format("Found ECU address: 0x%s", address));
 							// and add to list of addresses
 							ecuAddresses.add(Integer.valueOf(address, 16));
+							lastRxMsg = bufferStr.substring(adrStart+adrLen);
 						}
-						return lastRxMsg.length();
+						// return lastRxMsg.length();
 					}
+
 					default:
 						break;
 				}

--- a/library/src/test/java/com/fr3ts0n/ecu/prot/obd/ElmProtTest.java
+++ b/library/src/test/java/com/fr3ts0n/ecu/prot/obd/ElmProtTest.java
@@ -256,4 +256,34 @@ class ElmProtTest
 		assertEquals(true, ObdProt.tCodes.containsKey(0x0456));
 		assertEquals(true, ObdProt.tCodes.containsKey(0x0789));
 	}
+
+	@Test
+	/**
+	 * Read PID support telegram with ISO header
+	 * @Verifies AndrOBD #348
+	 */
+	void handleTgmReadObdData_ISO_Header()
+	{
+		prot.setService(ObdProt.OBD_SVC_DATA);
+		// OBD data pid list with ISO header bytes
+		prot.handleTelegram("86F1104100BE3EB8118D".toCharArray());
+		// ensure, trailing padding bytes are detected and cut off
+		// BE3EB811 -> PID's 1,5,12,13,14 ... set
+		assertEquals(1, prot.getNextSupportedPid());
+		assertEquals(3, prot.getNextSupportedPid());
+		assertEquals(4, prot.getNextSupportedPid());
+		assertEquals(5, prot.getNextSupportedPid());
+		assertEquals(6, prot.getNextSupportedPid());
+		assertEquals(7, prot.getNextSupportedPid());
+		assertEquals(11, prot.getNextSupportedPid());
+		assertEquals(12, prot.getNextSupportedPid());
+		assertEquals(13, prot.getNextSupportedPid());
+		assertEquals(14, prot.getNextSupportedPid());
+		assertEquals(15, prot.getNextSupportedPid());
+		assertEquals(17, prot.getNextSupportedPid());
+		assertEquals(19, prot.getNextSupportedPid());
+		assertEquals(20, prot.getNextSupportedPid());
+		assertEquals(21, prot.getNextSupportedPid());
+		assertEquals(28, prot.getNextSupportedPid());
+	}
 }


### PR DESCRIPTION
AndrOBD does not corretly decode ISO9141 telegram headers

Issue #348 shows that a telegram containing ISO header does not get interpreted correctly.

Since the used adapter indicates a problem when ATH headers are deactivated, AndrOBD shall decode ISO headers and interpret telegram content.