### PR TITLE
docs: correct stale AppCompatActivity comment in applyThemeMode() (follow-up to #354)

### DIFF
--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/MainActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/MainActivity.java
@@ -1706,10 +1706,11 @@ public class MainActivity extends PluginManager
 
     /**
      * Apply the tri-state theme preference application-wide via AppCompatDelegate.
-     * MainActivity itself isn't an AppCompatActivity (it extends the legacy
-     * ListActivity via PluginManager), so a live preference change needs an
-     * explicit recreate() here to pick up the new theme; other activities in
-     * this app are AppCompatActivity subclasses and re-theme automatically.
+     * PluginManager (MainActivity's superclass) migrated to AppCompatActivity in
+     * AndrOBD-libplugin#36, so AppCompatDelegate's override reaches MainActivity
+     * correctly like any other activity here; this explicit recreate() is just a
+     * belt-and-braces trigger for a live preference change, not a workaround for
+     * a missing AppCompatActivity base.
      */
     private void applyThemeMode(boolean recreateIfChanged)
     {


### PR DESCRIPTION
Small doc-only follow-up to #354 — no behaviour change.

#354's `applyThemeMode()` comment documented MainActivity as still `ListActivity`-based ("AppCompatDelegate's explicit Light/Dark override never reaches it"). That was already stale by the time #354 was tested: `PluginManager` (MainActivity's superclass) migrated to `AppCompatActivity` in AndrOBD-libplugin#36, merged 2026-07-11 — three weeks before #354 was opened.

Verified live on the Pixel 10 against current `master`:
- Settings > Theme switched between Light/Dark, checked live (in-session toggle) and via a genuine cold start (force-stop + relaunch) — MainActivity re-themes correctly both ways, same as every other screen.

Corrected the comment to reflect that. The `recreate()` call itself is untouched — it's a harmless explicit trigger either way, just no longer a documented workaround for a missing `AppCompatActivity` base.
