### PR TITLE
fix: log the real TX error exception instead of an array toString() (#348)

### DIFF
--- a/library/src/main/java/com/fr3ts0n/prot/StreamHandler.java
+++ b/library/src/main/java/com/fr3ts0n/prot/StreamHandler.java
@@ -110,9 +110,8 @@ public class StreamHandler implements TelegramWriter, Runnable
 				}
 				catch (Exception ex)
 				{
-					log.severe("TX error:'"
-					           + ProtUtils.hexDumpBuffer(buffer) + "':"
-					           + ex.getStackTrace());
+					log.log(Level.SEVERE, "TX error:'"
+					           + ProtUtils.hexDumpBuffer(buffer) + "'", ex);
 				}
 			}
 		}).start();


### PR DESCRIPTION
Fixes the garbled TX error log seen in #348 — no hardware needed to spot or fix this one, it's a logging bug in `StreamHandler`.

`writeTelegram()`'s catch block does:

```java
log.severe("TX error:'" + ProtUtils.hexDumpBuffer(buffer) + "':" + ex.getStackTrace());
```

`ex.getStackTrace()` returns `StackTraceElement[]`, so string concatenation just calls `Object.toString()` on the array — `[Ljava.lang.StackTraceElement;@c71e1ed`, discarding the exception's real type and message. That's exactly the output pasted into #348:

```
SEVERE stream TX error:'30 39 30 30 : 0900':[Ljava.lang.StackTraceElement;@c71e1ed
```

Switched to the `Logger.log(Level, String, Throwable)` overload, which formats the throwable properly — same pattern already used correctly two files over in `UsbCommService.java:261` (`log.log(Level.SEVERE, "TX error", ex)`). No behaviour change beyond what actually gets logged.

This won't fix the underlying TX failure on its own, but it should surface the real exception next time it's reproduced on #348, which looked like the actual blocker for diagnosing it further.

Cross-ref: #348
