### PR TITLE
feat: migrate BT/BLE/USB device pickers to RecyclerView

### DIFF
--- a/androbd/build.gradle
+++ b/androbd/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.8.0'
     implementation 'com.google.android.material:material:1.14.0'
     implementation 'androidx.preference:preference:1.2.1'
+    implementation 'androidx.recyclerview:recyclerview:1.4.0'
 
     // Local (JVM) unit tests
     testImplementation 'junit:junit:4.13.2'

--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/BleDeviceListActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/BleDeviceListActivity.java
@@ -7,6 +7,7 @@ import android.bluetooth.le.ScanCallback;
 import android.bluetooth.le.ScanResult;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import android.os.Bundle;
 
 import androidx.annotation.RequiresApi;
 import androidx.core.app.ActivityCompat;
@@ -19,6 +20,12 @@ public class BleDeviceListActivity
     extends BtDeviceListActivity
 {
     private BluetoothLeScanner leScanner;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mEmptyStateView.setText(R.string.no_ble_devices_found);
+    }
 
     @SuppressLint("InlinedApi")
     @Override

--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/BtDeviceListActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/BtDeviceListActivity.java
@@ -22,7 +22,6 @@ import android.Manifest;
 import android.annotation.SuppressLint;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
-import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Build;
@@ -30,18 +29,18 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
-import android.widget.AdapterView.OnItemClickListener;
-import android.widget.ArrayAdapter;
-import android.widget.ListView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.android.material.progressindicator.LinearProgressIndicator;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -63,7 +62,10 @@ public class BtDeviceListActivity extends AppCompatActivity
 
 	// Member fields
 	protected BluetoothAdapter mBtAdapter;
-	protected ArrayAdapter<BluetoothDevice> mBtDevices;
+	protected final List<BluetoothDevice> mDevices = new ArrayList<>();
+	protected DeviceAdapter mDeviceAdapter;
+	protected TextView mEmptyStateView;
+	protected LinearProgressIndicator mScanProgress;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState)
@@ -87,62 +89,97 @@ public class BtDeviceListActivity extends AppCompatActivity
 		setResult(RESULT_CANCELED);
 		// Setup the window
 		setContentView(R.layout.device_list);
-		
+
 		// Get the local Bluetooth adapter
 		mBtAdapter = BluetoothAdapter.getDefaultAdapter();
 		stopDeviceScan();
 
-		mBtDevices =
-			new ArrayAdapter<BluetoothDevice>(this, R.layout.device_name){
-				final LayoutInflater mInflater =
-						(LayoutInflater)getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-				@SuppressLint("MissingPermission")
-                @NonNull
-				@Override
-				public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
-					TextView tv;
-					BluetoothDevice dev = getItem(position);
-					if (convertView != null) {
-						tv = (TextView) convertView;
-					} else {
-						tv = (TextView)mInflater.inflate(R.layout.device_name,
-														 parent,
-											 false);
-					}
-					String displayName;
-					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-						String alias = dev.getAlias();
-						displayName = (alias != null && !alias.isEmpty()) ? alias : dev.getName();
-					} else {
-						displayName = dev.getName();
-					}
-					tv.setText(String.format("%s\n%s", displayName, dev.getAddress()));
-					return tv;
-				}
-			};
-		
-		// Find and set up the ListView for paired devices
-		ListView pairedListView = findViewById(R.id.list);
-		pairedListView.setAdapter(mBtDevices);
-		// set up list selection handlers
-		pairedListView.setOnItemClickListener(mDeviceClickListener);
+		// Find and set up the RecyclerView for paired devices
+		RecyclerView pairedListView = findViewById(R.id.list);
+		pairedListView.setLayoutManager(new LinearLayoutManager(this));
+		mDeviceAdapter = new DeviceAdapter();
+		pairedListView.setAdapter(mDeviceAdapter);
+
+		mEmptyStateView = findViewById(R.id.empty_state);
+		mEmptyStateView.setText(R.string.no_paired_devices);
+		mScanProgress = findViewById(R.id.scan_progress);
+
+		updateEmptyState();
 	}
 
 	@Override
 	protected void onStart() {
 		super.onStart();
+		mScanProgress.setVisibility(View.VISIBLE);
 		startDeviceScan();
 	}
 
 	@Override
 	protected void onStop() {
 		super.onStop();
+		mScanProgress.setVisibility(View.GONE);
 		stopDeviceScan();
 	}
 
 	protected void addDevice(BluetoothDevice device) {
-		if (mBtDevices.getPosition(device) < 0) {
-			mBtDevices.add(device);
+		if (!mDevices.contains(device)) {
+			mDevices.add(device);
+			mDeviceAdapter.notifyItemInserted(mDevices.size() - 1);
+			updateEmptyState();
+		}
+	}
+
+	protected void updateEmptyState() {
+		mEmptyStateView.setVisibility(mDevices.isEmpty() ? View.VISIBLE : View.GONE);
+	}
+
+	/** Called when the user picks a device from the list. */
+	protected void onDeviceSelected(BluetoothDevice device) {
+		// Create the result Intent and include the MAC address
+		Intent intent = new Intent();
+		intent.putExtra(EXTRA_DEVICE_ADDRESS, device.getAddress());
+
+		// Set result and finish this Activity
+		setResult(RESULT_OK, intent);
+		log.log(Level.FINE, "Sending Result...");
+		finish();
+	}
+
+	protected static class DeviceViewHolder extends RecyclerView.ViewHolder {
+		final TextView text;
+		DeviceViewHolder(@NonNull View itemView) {
+			super(itemView);
+			text = (TextView) itemView;
+		}
+	}
+
+	protected class DeviceAdapter extends RecyclerView.Adapter<DeviceViewHolder> {
+		@NonNull
+		@Override
+		public DeviceViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+			View v = LayoutInflater.from(parent.getContext())
+				.inflate(R.layout.device_name, parent, false);
+			return new DeviceViewHolder(v);
+		}
+
+		@SuppressLint("MissingPermission") // permission is checked before
+		@Override
+		public void onBindViewHolder(@NonNull DeviceViewHolder holder, int position) {
+			BluetoothDevice dev = mDevices.get(position);
+			String displayName;
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+				String alias = dev.getAlias();
+				displayName = (alias != null && !alias.isEmpty()) ? alias : dev.getName();
+			} else {
+				displayName = dev.getName();
+			}
+			holder.text.setText(String.format("%s\n%s", displayName, dev.getAddress()));
+			holder.itemView.setOnClickListener(v -> onDeviceSelected(dev));
+		}
+
+		@Override
+		public int getItemCount() {
+			return mDevices.size();
 		}
 	}
 
@@ -165,25 +202,4 @@ public class BtDeviceListActivity extends AppCompatActivity
 			// Cancel discovery because it's costly and we're about to connect
 			mBtAdapter.cancelDiscovery();
 	}
-
-	// The on-click listener for all devices in the ListViews
-	private final OnItemClickListener mDeviceClickListener = new OnItemClickListener()
-	{
-		public void onItemClick(AdapterView<?> av, View v, int position, long id)
-		{
-			// Get the device MAC address, which is the last 17 chars in the View
-			//String address = "00:0D:18:A0:4E:35"; //FORCE OBD MAC Address
-			BluetoothDevice currDev = (BluetoothDevice)av.getItemAtPosition(position);
-			String address = currDev.getAddress();
-
-			// Create the result Intent and include the MAC address
-			Intent intent = new Intent();
-			intent.putExtra(EXTRA_DEVICE_ADDRESS, address);
-
-			// Set result and finish this Activity
-			setResult(RESULT_OK, intent);
-			log.log(Level.FINE, "Sending Result...");
-			finish();
-		}
-	};
 }

--- a/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/UsbDeviceListActivity.java
+++ b/androbd/src/main/java/com/fr3ts0n/ecu/gui/androbd/UsbDeviceListActivity.java
@@ -31,14 +31,14 @@ import android.os.Message;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
-import android.widget.ArrayAdapter;
-import android.widget.ListView;
 import android.widget.TextView;
-import android.widget.TwoLineListItem;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.android.material.progressindicator.LinearProgressIndicator;
 import com.hoho.android.usbserial.driver.UsbSerialDriver;
 import com.hoho.android.usbserial.driver.UsbSerialPort;
 import com.hoho.android.usbserial.driver.UsbSerialProber;
@@ -87,7 +87,9 @@ public final class UsbDeviceListActivity extends AppCompatActivity
 	};
 
 	private final List<UsbSerialPort> mEntries = new ArrayList<>();
-	private ArrayAdapter<UsbSerialPort> mAdapter;
+	private UsbAdapter mAdapter;
+	private TextView mEmptyStateView;
+	private LinearProgressIndicator mScanProgress;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState)
@@ -96,70 +98,63 @@ public final class UsbDeviceListActivity extends AppCompatActivity
 		setContentView(R.layout.usb_list);
 
 		mUsbManager = (UsbManager) getSystemService(Context.USB_SERVICE);
-		ListView mListView = findViewById(R.id.deviceList);
-		mAdapter = new ArrayAdapter<UsbSerialPort>(this,
-		                                           android.R.layout.simple_expandable_list_item_2,
-		                                           mEntries)
-		{
-			@Override
-			public View getView(int position, View convertView, ViewGroup parent)
-			{
-				final TwoLineListItem row;
-				if (convertView == null)
-				{
-					final LayoutInflater inflater =
-						(LayoutInflater) getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-					row = (TwoLineListItem) (inflater != null ? inflater.inflate(
-						android.R.layout.simple_list_item_2, null) : null);
-				} else
-				{
-					row = (TwoLineListItem) convertView;
-				}
-
-				if (row != null)
-				{
-					final UsbSerialPort port = mEntries.get(position);
-					final UsbSerialDriver driver = port.getDriver();
-					final UsbDevice device = driver.getDevice();
-	
-					final String title = String.format("USB: 0x%04x/0x%04x",
-					                                   device.getVendorId(),
-					                                   device.getProductId());
-					final String subtitle = driver.getClass().getSimpleName();
-
-					row.getText1().setText(title);
-					row.getText2().setText(subtitle);
-				}
-				
-				//noinspection ConstantConditions
-				return row;
-			}
-
-		};
+		RecyclerView mListView = findViewById(R.id.deviceList);
+		mListView.setLayoutManager(new LinearLayoutManager(this));
+		mAdapter = new UsbAdapter();
 		mListView.setAdapter(mAdapter);
 
-		mListView.setOnItemClickListener(new ListView.OnItemClickListener()
-		{
-			@Override
-			public void onItemClick(AdapterView<?> parent, View view, int position, long id)
-			{
-				log.fine("Pressed item " + position);
-				if (position >= mEntries.size())
-				{
-					log.warning("Illegal position.");
-					return;
-				}
+		mEmptyStateView = findViewById(R.id.empty_state);
+		mEmptyStateView.setText(R.string.no_usb_devices_found);
+		mScanProgress = findViewById(R.id.scan_progress);
+	}
 
-				selectedPort = mEntries.get(position);
+	private void onPortSelected(UsbSerialPort port) {
+		selectedPort = port;
 
-				// Create the result Intent and include the MAC address
-				Intent intent = new Intent();
-				// Set result and finish this Activity
-				setResult(RESULT_OK, intent);
-				log.fine("Sending Result...");
-				finish();
-			}
-		});
+		// Create the result Intent and include the MAC address
+		Intent intent = new Intent();
+		// Set result and finish this Activity
+		setResult(RESULT_OK, intent);
+		log.fine("Sending Result...");
+		finish();
+	}
+
+	private static class DeviceViewHolder extends RecyclerView.ViewHolder {
+		final TextView text;
+		DeviceViewHolder(@NonNull View itemView) {
+			super(itemView);
+			text = (TextView) itemView;
+		}
+	}
+
+	private class UsbAdapter extends RecyclerView.Adapter<DeviceViewHolder> {
+		@NonNull
+		@Override
+		public DeviceViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+			View v = LayoutInflater.from(parent.getContext())
+				.inflate(R.layout.device_name, parent, false);
+			return new DeviceViewHolder(v);
+		}
+
+		@Override
+		public void onBindViewHolder(@NonNull DeviceViewHolder holder, int position) {
+			final UsbSerialPort port = mEntries.get(position);
+			final UsbSerialDriver driver = port.getDriver();
+			final UsbDevice device = driver.getDevice();
+
+			final String title = String.format("USB: 0x%04x/0x%04x",
+			                                   device.getVendorId(),
+			                                   device.getProductId());
+			final String subtitle = driver.getClass().getSimpleName();
+
+			holder.text.setText(String.format("%s\n%s", title, subtitle));
+			holder.itemView.setOnClickListener(v -> onPortSelected(port));
+		}
+
+		@Override
+		public int getItemCount() {
+			return mEntries.size();
+		}
 	}
 
 	@Override
@@ -176,9 +171,13 @@ public final class UsbDeviceListActivity extends AppCompatActivity
 		mHandler.removeMessages(MESSAGE_REFRESH);
 	}
 
-	@SuppressLint("StringFormatInvalid")
+	// The device list is small and rebuilt wholesale every poll (no drivers persist across a
+	// refresh), so a full notifyDataSetChanged is genuinely simplest here — not worth a DiffUtil
+	// for a handful of items on a 5-second timer.
+	@SuppressLint({"StringFormatInvalid", "NotifyDataSetChanged"})
 	private void refreshDeviceList()
 	{
+		mScanProgress.setVisibility(View.VISIBLE);
 		mExecutor.submit(() -> {
 			log.fine("Refreshing device list ...");
 			final List<UsbSerialDriver> drivers =
@@ -198,6 +197,8 @@ public final class UsbDeviceListActivity extends AppCompatActivity
 				TextView numFound = findViewById(R.id.num_found);
 				numFound.setText(getString(R.string.devices_found, result.size()));
 				mAdapter.notifyDataSetChanged();
+				mEmptyStateView.setVisibility(mEntries.isEmpty() ? View.VISIBLE : View.GONE);
+				mScanProgress.setVisibility(View.GONE);
 				log.fine("Done refreshing, " + mEntries.size() + " entries found.");
 			});
 		});

--- a/androbd/src/main/res/layout/device_list.xml
+++ b/androbd/src/main/res/layout/device_list.xml
@@ -1,11 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    >
-    <ListView android:id="@+id/list"
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        />
+
+    <TextView
+        android:id="@+id/empty_state"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:textSize="18sp"
+        android:padding="16dp"
+        android:gravity="center"
+        android:visibility="gone"
+        />
+
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/scan_progress"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-    />
-</LinearLayout>
+        android:layout_gravity="top"
+        android:indeterminate="true"
+        android:visibility="gone"
+        />
+
+</merge>

--- a/androbd/src/main/res/layout/usb_list.xml
+++ b/androbd/src/main/res/layout/usb_list.xml
@@ -32,8 +32,35 @@
         android:paddingLeft="5dp"
         />
 
-    <ListView
-        android:id="@+id/deviceList"
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/scan_progress"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:visibility="gone"
+        />
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        >
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/deviceList"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            />
+
+        <TextView
+            android:id="@+id/empty_state"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:textSize="18sp"
+            android:padding="16dp"
+            android:gravity="center"
+            android:visibility="gone"
+            />
+
+    </FrameLayout>
 </LinearLayout>

--- a/androbd/src/main/res/values/strings.xml
+++ b/androbd/src/main/res/values/strings.xml
@@ -170,6 +170,9 @@ period of time while the ECU recalibrates itself.
     <string name="select_fault_code">Select fault code …</string>
     <string name="select_medium">Adapter type …</string>
     <string name="devices_found">%d USB device(s) found</string>
+    <string name="no_paired_devices">No paired devices found. Pair a device in Bluetooth settings first.</string>
+    <string name="no_ble_devices_found">No devices found nearby.</string>
+    <string name="no_usb_devices_found">No USB devices found.</string>
     <string name="min_elm_timeout">Min. ELM timeout [ms]</string>
     <string name="unabletoconnect">Unable to connect device</string>
     <string name="connectionlost">Device connection was lost</string>


### PR DESCRIPTION
Part of the staged Material migration under #104 (item 5 of the P2-002d+ component-migration list).

## What changed
`BtDeviceListActivity`, `BleDeviceListActivity`, and `UsbDeviceListActivity` all used `ListView`/`ArrayAdapter`. This migrates all three to `RecyclerView`, and adds two things that were missing before: an empty-state message when no devices are found, and a scan-progress indicator so there's some feedback that discovery is actually happening.

- `BtDeviceListActivity`'s `ArrayAdapter` is now a `RecyclerView.Adapter` over a plain `List<BluetoothDevice>`, reusing the existing `device_name.xml` item layout. `BluetoothDevice.equals()` compares by address, so the dedup-on-add logic is unchanged.
- `BleDeviceListActivity` (extends `BtDeviceListActivity`) only needed a small `onCreate` override for its own empty-state text.
- `UsbDeviceListActivity`'s `ArrayAdapter`/`TwoLineListItem` became its own `RecyclerView.Adapter`, reusing `device_name.xml` with the same `"%s\n%s"` two-line format the BT screens use, rather than adding a second item layout.
- Added `androidx.recyclerview:recyclerview:1.4.0` (not previously a dependency).
- The scan-progress indicator shows for the whole `onStart`–`onStop` lifetime on the BT/BLE screens (accurate for BLE's ongoing scan; a brief flash for classic BT's synchronous paired-device lookup), and toggles around each 5-second poll on the USB screen using its existing refresh cycle.

## Verification
`assembleDebug`, `lintDebug`, and `testDebugUnitTest` all clean (32 pre-existing lint warnings unrelated to this change, baseline untouched). Not verified on a real device this session — no BT/BLE/USB hardware to hand — so I'd appreciate a look on your end before merging, same as the other picker-adjacent PRs.

AI disclosure: drafted with Claude Code assistance; reasoning and diff reviewed before opening.